### PR TITLE
ci: fix missing_docs lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ explicit_iter_loop = "warn"
 future_not_send = "warn"
 todo = "warn"
 use_self = "warn"
-missing_docs = "warn"
 
 [workspace.lints.rust]
 missing_copy_implementations = "warn"
 missing_debug_implementations = "warn"
 unused_crate_dependencies = "warn"
 unreachable_pub = "warn"
+missing_docs = "warn"

--- a/libtlafmt/build.rs
+++ b/libtlafmt/build.rs
@@ -1,4 +1,6 @@
-pub fn main() {
+#![allow(missing_docs)]
+
+fn main() {
     // This statement prevents cargo from complaining about an unknown (to it)
     // cfg for fuzzing.
     println!("cargo::rustc-check-cfg=cfg(fuzzing)");


### PR DESCRIPTION
This fixes CI lints for the presence of docs.

---

* ci: fix missing_docs lint (0a3ee2b)
      
      It was in the "clippy" block, but this is a rustc lint.