### PR TITLE
fix: indentation rewriter pass & spacing fixes

### DIFF
--- a/libtlafmt/src/ast_format/node.rs
+++ b/libtlafmt/src/ast_format/node.rs
@@ -685,4 +685,53 @@ X == "bananas"
 "#
         );
     }
+
+    #[test]
+    fn test_spec_always_true_ident() {
+        assert_rewrite!(
+            r#"
+---- MODULE B ----
+LEMMA TypeCorrect == Spec => []TypeInv
+THEOREM DeadlockFreedom == Spec => [] Invariant
+====
+"#
+        );
+    }
+
+    /// Reproducer for https://github.com/domodwyer/tlafmt/issues/25.
+    #[test]
+    fn test_bounded_quantification() {
+        assert_rewrite!(
+            r#"
+---- MODULE B ----
+FairSpec ==
+    /\ Spec
+
+    \* Assert that producers take steps should their  Put  action be (continuously)
+    \* enabled. This is the basic case of fairness that rules out stuttering, i.e.,
+    \* assert global progress.
+    /\ \A t \in Producers:
+            WF_vars(Put(t,t))
+    \* Stipulates that  Get  actions (consumers!) will eventually notify *all*
+    \* waiting producers. In other words, given repeated  Get  actions (we don't
+    \* care which consumer, thus, existential quantification), all waiting
+    \* producers will eventually be notified.  Because  Get  actions are not
+    \* continuously enabled (the buffer might be empty), weak fairness is not
+    \* strong enough. Obviously, no real system scheduler implements such an
+    \* inefficient "policy".
+    \* This fairness constraint was initially proposed by Leslie Lamport, although
+    \* with the minor typo "in" instead of "notin", which happens to hold for
+    \* configurations with at most two producers.
+    /\ \A t \in Producers:
+            SF_vars(\E self \in Consumers: Get(self) /\ t \notin waitSet')
+
+    \* See notes above (except swap "producer" with "consumer").
+    /\ \A t \in Consumers:
+            WF_vars(Get(t))
+    /\ \A t \in Consumers:
+            SF_vars(\E self \in Producers: Put(self, self) /\ t \notin waitSet')
+====
+"#
+        );
+    }
 }

--- a/libtlafmt/src/ast_format/node.rs
+++ b/libtlafmt/src/ast_format/node.rs
@@ -74,8 +74,8 @@ where
         "disj_item",
         "conj_item",
         "let_in",
-        // ---
         "bounded_quantification",
+        // ---
         "bound_infix_op",
         "except",
         "extends",
@@ -130,7 +130,7 @@ where
         }
 
         // These are always indented.
-        "disj_list" | "conj_list" | "let_in" => skip_indent = false,
+        "disj_list" | "conj_list" | "let_in" | "bounded_quantification" => skip_indent = false,
 
         // Operators are not indented if they are the top level definition, and
         // are indented if they are within a definition (excluding LOCALs).

--- a/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__bounded_quantification.snap
+++ b/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__bounded_quantification.snap
@@ -10,7 +10,7 @@ FairSpec ==
     \* enabled. This is the basic case of fairness that rules out stuttering, i.e.,
     \* assert global progress.
     /\ \A t \in Producers:
-    WF_vars(Put(t, t))
+        WF_vars(Put(t, t))
     \* Stipulates that  Get  actions (consumers!) will eventually notify *all*
     \* waiting producers. In other words, given repeated  Get  actions (we don't
     \* care which consumer, thus, existential quantification), all waiting
@@ -22,11 +22,11 @@ FairSpec ==
     \* with the minor typo "in" instead of "notin", which happens to hold for
     \* configurations with at most two producers.
     /\ \A t \in Producers:
-    SF_vars(\E self \in Consumers: Get(self) /\ t \notin waitSet')
+        SF_vars(\E self \in Consumers: Get(self) /\ t \notin waitSet')
 
     \* See notes above (except swap "producer" with "consumer").
     /\ \A t \in Consumers:
-    WF_vars(Get(t))
+        WF_vars(Get(t))
     /\ \A t \in Consumers:
-    SF_vars(\E self \in Producers: Put(self, self) /\ t \notin waitSet')
+        SF_vars(\E self \in Producers: Put(self, self) /\ t \notin waitSet')
 ================================================================================

--- a/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__bounded_quantification.snap
+++ b/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__bounded_quantification.snap
@@ -1,0 +1,32 @@
+---
+source: libtlafmt/src/ast_format/node.rs
+expression: output
+---
+----------------------------------- MODULE B -----------------------------------
+FairSpec ==
+    /\ Spec
+
+    \* Assert that producers take steps should their  Put  action be (continuously)
+    \* enabled. This is the basic case of fairness that rules out stuttering, i.e.,
+    \* assert global progress.
+    /\ \A t \in Producers:
+    WF_vars(Put(t, t))
+    \* Stipulates that  Get  actions (consumers!) will eventually notify *all*
+    \* waiting producers. In other words, given repeated  Get  actions (we don't
+    \* care which consumer, thus, existential quantification), all waiting
+    \* producers will eventually be notified.  Because  Get  actions are not
+    \* continuously enabled (the buffer might be empty), weak fairness is not
+    \* strong enough. Obviously, no real system scheduler implements such an
+    \* inefficient "policy".
+    \* This fairness constraint was initially proposed by Leslie Lamport, although
+    \* with the minor typo "in" instead of "notin", which happens to hold for
+    \* configurations with at most two producers.
+    /\ \A t \in Producers:
+    SF_vars(\E self \in Consumers: Get(self) /\ t \notin waitSet')
+
+    \* See notes above (except swap "producer" with "consumer").
+    /\ \A t \in Consumers:
+    WF_vars(Get(t))
+    /\ \A t \in Consumers:
+    SF_vars(\E self \in Producers: Put(self, self) /\ t \notin waitSet')
+================================================================================

--- a/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__if_then_else.snap
+++ b/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__if_then_else.snap
@@ -9,5 +9,5 @@ DoStuff ==
     ELSE
     24
 
-MoreStuff = IF == x THEN 42 ELSE 24 
+MoreStuff = IF == x THEN 42 ELSE 24
 ================================================================================

--- a/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__newline_indent_non_list.snap
+++ b/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__newline_indent_non_list.snap
@@ -6,13 +6,13 @@ expression: output
 NoVal ==
     CHOOSE v:
 
-        v \notin
-        Val
+    v \notin
+    Val
 
 \* Bananas are good
 Store ==
     [Key ->
-            Val \union {NoVal}]
+        Val \union {NoVal}]
 
 \* Set map
 Map ==

--- a/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__spec_always_true_ident.snap
+++ b/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__spec_always_true_ident.snap
@@ -3,6 +3,6 @@ source: libtlafmt/src/ast_format/node.rs
 expression: output
 ---
 ----------------------------------- MODULE B -----------------------------------
-LEMMA TypeCorrect == Spec => [] TypeInv
-THEOREM DeadlockFreedom == Spec => [] Invariant
+LEMMA TypeCorrect == Spec => []TypeInv
+THEOREM DeadlockFreedom == Spec => []Invariant
 ================================================================================

--- a/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__spec_always_true_ident.snap
+++ b/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__spec_always_true_ident.snap
@@ -1,0 +1,8 @@
+---
+source: libtlafmt/src/ast_format/node.rs
+expression: output
+---
+----------------------------------- MODULE B -----------------------------------
+ LEMMA TypeCorrect == Spec => [] TypeInv
+THEOREM DeadlockFreedom == Spec => [] Invariant
+================================================================================

--- a/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__spec_always_true_ident.snap
+++ b/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__spec_always_true_ident.snap
@@ -3,6 +3,6 @@ source: libtlafmt/src/ast_format/node.rs
 expression: output
 ---
 ----------------------------------- MODULE B -----------------------------------
- LEMMA TypeCorrect == Spec => [] TypeInv
+LEMMA TypeCorrect == Spec => [] TypeInv
 THEOREM DeadlockFreedom == Spec => [] Invariant
 ================================================================================

--- a/libtlafmt/src/renderer/indent.rs
+++ b/libtlafmt/src/renderer/indent.rs
@@ -1,0 +1,392 @@
+use crate::token::Token;
+
+use super::Indent;
+
+/// Process the token buffer, reducing the indentation of excessively indented
+/// blocks relative to the previous line.
+///
+/// An excessively indented block is one in which all tokens within it are more
+/// than 1 level deeper in indentation than the parent. It rewrites this:
+///
+/// ```text
+///    LET n == Len(InitVals)
+///            gg == CHOOSE g:
+///                    \E e \in PosReal:
+///                        /\ \A r \in OpenInterval(a - e, b + e):
+///                                    D[X |-> 42] = 0
+/// ```
+///
+/// Into this:
+///
+/// ```text
+///    LET n == Len(InitVals)
+///        gg == CHOOSE g:
+///            \E e \in PosReal:
+///                /\ \A r \in OpenInterval(a - e, b + e):
+///                     D[X |-> 42] = 0
+/// ```
+///
+pub(super) fn limit_indents(buf: &mut [(Token<'_>, Indent)]) {
+    recurse(buf);
+}
+
+/// The indentation rewriter state.
+///
+/// In these comments, the "current" indentation level refers to the indentation
+/// level at which the first token in a call to [`recurse()`] is observed.
+///
+/// The "current block" is all nodes indented at the "current" indentation level
+/// or greater.
+///
+/// ```text
+///                           Current Indent
+///                                Level
+///                                  │
+///                                  ▼
+///                               ┌─
+///                               │  A
+///                               │
+///                               │  A
+///                               │
+///                               │     B
+///                               │
+///                     Current   │        C
+///                      Block    │
+///                               │     B
+///                               │
+///                               │     B
+///                               │
+///                               │  A
+///                               └─
+///
+/// ```
+///
+#[derive(Debug)]
+enum State {
+    /// Consume tokens that are at the same indent level as the current block.
+    ///
+    /// Transitions to [`State::Scanning`] when excessive indentation is found.
+    Skipping,
+
+    /// Potentially excessive indentation has been found.
+    ///
+    /// Scan through tokens looking for the minimum indent that exceeds the
+    /// current indent level, at which point transition to [`State::Rewriting`]
+    /// to correct it if it is `> current + 1`, else transitions back to
+    /// [`State::Skipping`].
+    ScanningMin {
+        /// The index at which the transition to this state occurred, which is
+        /// the index where the excessive indentation begins.
+        start_index: usize,
+
+        /// The min observed indention level within the nested block.
+        min: Indent,
+    },
+
+    /// Adjust any indentation level at or above the current block's indent
+    /// depth by reducing indentation by the number of levels specified in
+    /// `delta`.
+    ///
+    /// Once the current block ends (the indention is strictly less than the
+    /// current block), the state transitions back to [`State::Skipping`].
+    Rewriting {
+        /// The index at which this first token of excessive indentation was
+        /// found.
+        start_index: usize,
+
+        /// The (positive) adjustment to subtract from the nested block
+        /// indentation level.
+        delta: Indent,
+    },
+}
+
+fn recurse(buf: &mut [(Token<'_>, Indent)]) -> usize {
+    // Extract the current indentation depth for this call to operate relative
+    // to.
+    let current_depth = match buf.first() {
+        Some((_, v)) => *v,
+        None => {
+            return 0;
+        }
+    };
+
+    // The rewrite state.
+    let mut state = State::Skipping;
+
+    // Indentation is only effective immediately following a newline token,
+    // therefore only those tokens are considered when advancing the FSM or
+    // rewriting indentation levels.
+    let mut last_was_newline = false;
+
+    let mut i = 0;
+    while i < buf.len() {
+        // Observe if this token is a newline, and skip visiting it if the last
+        // token was not a newline.
+        let last = last_was_newline;
+        last_was_newline = matches!(buf[i].0, Token::Newline | Token::SourceNewline);
+        if !last {
+            i += 1;
+            continue;
+        }
+
+        // Extract the indentation level of this token.
+        let this = buf[i].1;
+
+        match state {
+            // Skip tokens at the same indentation level.
+            State::Skipping if this == current_depth => {}
+
+            // Recurse into an nested block of +1 depth for processing.
+            State::Skipping if this == current_depth + 1 => {
+                i += recurse(&mut buf[i..]);
+                continue;
+            }
+
+            // This MAY be excessively indented.
+            //
+            // To confirm, all tokens that are indented at this depth must be
+            // visited.
+            //
+            // An example of valid indentation that appears excessive without
+            // visiting all child nodes is:
+            //
+            //      Op == [
+            //              {
+            //          }
+            //      ]
+            //
+            // The transition from the first line to the second looks excessive,
+            // but a trailing bracket on the second to last line causes the
+            // indentation to be valid, as there are nodes at all indent depths.
+            State::Skipping if this > current_depth + 1 => {
+                // Transition to the "scanning" state to find the minimum indent
+                // indentation that is contained within the parent block.
+                state = State::ScanningMin {
+                    start_index: i,
+                    min: this,
+                }
+            }
+
+            // The indent depth has fallen below the current indent depth of
+            // this block.
+            State::Skipping => {
+                debug_assert!(this < current_depth);
+
+                // Optimisation: return the number of nodes visited at least
+                // once to allow the caller to advance past the nodes this call
+                // visited.
+                return i;
+            }
+
+            // The excessively indented, nested block was fully visited (by
+            // virtue of indentation dropping back to the current block's
+            // indentation level or less) and it did not take an early state
+            // transition back to skipping, meaning it is confirmed to be
+            // excessively indented.
+            State::ScanningMin { start_index, min } if this <= current_depth => {
+                // Reset the index back to the first occurrence of `child`,
+                // which is guaranteed to have followed a newline.
+                i = start_index;
+                last_was_newline = true;
+
+                // And begin reducing the indentation by the specified amount.
+                state = State::Rewriting {
+                    start_index,
+                    delta: min - current_depth - Indent(1),
+                };
+                continue;
+            }
+
+            // The early return when a possibly excessively indented, nested
+            // block contains a node at current + 1 meaning it was appropriately
+            // indented.
+            State::ScanningMin { start_index, min } if min == current_depth + 1 => {
+                state = State::Skipping;
+                i = start_index + recurse(&mut buf[start_index..]);
+                continue;
+            }
+
+            // Continue scanning within the nested block, looking for the min
+            // depth.
+            State::ScanningMin { start_index, min } => {
+                state = State::ScanningMin {
+                    start_index,
+                    min: std::cmp::min(min, this),
+                }
+            }
+
+            // Apply a delta adjustment to reduce this node's indentation level.
+            State::Rewriting { delta, .. } if this > current_depth => {
+                buf[i].1 = this - delta;
+            }
+
+            // This node reaches the end of the nested block.
+            //
+            // After processing the nested block, it needs to be recursed into
+            // to correct any further nested, excessively indented blocks
+            // relative to it.
+            State::Rewriting { start_index, .. } => {
+                state = State::Skipping;
+                i = start_index + recurse(&mut buf[start_index..]);
+                continue;
+            }
+        };
+
+        i += 1;
+    }
+
+    i
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::assert_rewrite;
+
+    use super::*;
+
+    #[test]
+    fn test_no_op() {
+        let tokens = [
+            (Token::Newline, Indent(1)),
+            (Token::Bang, Indent(1)),
+            (Token::Newline, Indent(1)),
+            (Token::Bang, Indent(1)),
+            (Token::Newline, Indent(1)),
+            (Token::Bang, Indent(1)),
+        ];
+
+        let mut got = tokens.clone();
+        limit_indents(&mut got);
+        assert_eq!(got, tokens);
+    }
+
+    #[test]
+    fn test_dedent_many() {
+        let mut tokens = [
+            (Token::Newline, Indent(1)),
+            (Token::Bang, Indent(1)),
+            (Token::Newline, Indent(3)),
+            (Token::Bang, Indent(3)),
+            (Token::Newline, Indent(5)),
+            (Token::Bang, Indent(5)),
+            (Token::Newline, Indent(3)),
+            (Token::Bang, Indent(3)),
+            (Token::Newline, Indent(1)),
+            (Token::Bang, Indent(1)),
+        ];
+
+        limit_indents(&mut tokens);
+        assert_eq!(
+            tokens,
+            [
+                (Token::Newline, Indent(1)),
+                (Token::Bang, Indent(1)),
+                (Token::Newline, Indent(3)), // Newline tokens are not rewrote
+                (Token::Bang, Indent(2)),
+                (Token::Newline, Indent(5)),
+                (Token::Bang, Indent(3)),
+                (Token::Newline, Indent(3)),
+                (Token::Bang, Indent(2)),
+                (Token::Newline, Indent(1)),
+                (Token::Bang, Indent(1)),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_dedent_one() {
+        let mut tokens = [
+            (Token::Newline, Indent(1)),
+            (Token::Bang, Indent(1)),
+            (Token::Newline, Indent(3)),
+            (Token::Bang, Indent(3)),
+            (Token::Newline, Indent(1)),
+            (Token::Bang, Indent(1)),
+        ];
+
+        limit_indents(&mut tokens);
+        assert_eq!(
+            tokens,
+            [
+                (Token::Newline, Indent(1)),
+                (Token::Bang, Indent(1)),
+                (Token::Newline, Indent(3)),
+                (Token::Bang, Indent(2)),
+                (Token::Newline, Indent(1)),
+                (Token::Bang, Indent(1)),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_step_jump() {
+        let mut tokens = [
+            (Token::Newline, Indent(1)),
+            (Token::Bang, Indent(1)),
+            (Token::Newline, Indent(2)),
+            (Token::Bang, Indent(2)),
+            (Token::Newline, Indent(5)),
+            (Token::Bang, Indent(5)),
+            (Token::Newline, Indent(5)),
+            (Token::Bang, Indent(5)),
+            (Token::Newline, Indent(1)),
+            (Token::Bang, Indent(1)),
+        ];
+
+        limit_indents(&mut tokens);
+        assert_eq!(
+            tokens,
+            [
+                (Token::Newline, Indent(1)),
+                (Token::Bang, Indent(1)),
+                (Token::Newline, Indent(2)),
+                (Token::Bang, Indent(2)),
+                (Token::Newline, Indent(5)),
+                (Token::Bang, Indent(3)),
+                (Token::Newline, Indent(5)),
+                (Token::Bang, Indent(3)),
+                (Token::Newline, Indent(1)),
+                (Token::Bang, Indent(1)),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_deferred_indent_use() {
+        let tokens = [
+            (Token::Newline, Indent(1)),
+            (Token::Bang, Indent(1)),
+            (Token::Newline, Indent(3)),
+            (Token::Bang, Indent(3)),
+            (Token::Newline, Indent(2)),
+            (Token::Bang, Indent(2)),
+        ];
+
+        let mut got = tokens.clone();
+        limit_indents(&mut got);
+        assert_eq!(got, tokens);
+    }
+
+    #[test]
+    fn test_let_in_record_literal() {
+        assert_rewrite!(
+            r"
+---- MODULE Bananas ----
+AppendEntries(i, j) ==
+    /\ LET prevLogIndex == nextIndex[i][j] - 1
+           prevLogTerm == IF prevLogIndex > 0 THEN
+                              log[i][prevLogIndex].term
+                          ELSE
+                              0
+           \* Send up to 1 entry, constrained by the end of the log.
+           lastEntry == Min({Len(log[i]), nextIndex[i][j]})
+           entries == SubSeq(log[i], nextIndex[i][j], lastEntry)
+       IN Send([mtype          |-> AppendEntriesRequest,
+                mterm          |-> currentTerm[i],
+                mprevLogIndex  |-> prevLogIndex,
+                mdest          |-> j])
+====
+"
+        )
+    }
+}

--- a/libtlafmt/src/renderer/mod.rs
+++ b/libtlafmt/src/renderer/mod.rs
@@ -600,6 +600,12 @@ mod tests {
 
         let output: String = format([Token::Raw("!!!"), Token::SourceNewline]);
         assert_eq!(output, "!!!\n");
+
+        let output: String = format([Token::Raw("!!!\n"), Token::Ident("bananas")]);
+        assert_eq!(output, "!!!\nbananas");
+
+        let output: String = format([Token::Raw("!!!\n"), Token::Ident("bananas")]);
+        assert_eq!(output, "!!!\nbananas");
     }
 
     /// An unhandled node that follows a newline should not be space delimited -

--- a/libtlafmt/src/renderer/mod.rs
+++ b/libtlafmt/src/renderer/mod.rs
@@ -584,4 +584,15 @@ mod tests {
         let output: String = format([Token::Ident("bananas"), Token::Raw("!!!"), Token::Lit("42")]);
         assert_eq!(output, "bananas !!! 42");
     }
+
+    /// An unhandled node that follows a newline should not be space delimited -
+    /// it leads to an unexpected space before the content of a line.
+    #[test]
+    fn test_raw_tokens_after_newlines() {
+        let output: String = format([Token::Newline, Token::Raw("!!!"), Token::Lit("42")]);
+        assert_eq!(output, "\n!!! 42");
+
+        let output: String = format([Token::SourceNewline, Token::Raw("!!!"), Token::Lit("42")]);
+        assert_eq!(output, "\n!!! 42");
+    }
 }

--- a/libtlafmt/src/renderer/mod.rs
+++ b/libtlafmt/src/renderer/mod.rs
@@ -588,11 +588,34 @@ mod tests {
     /// An unhandled node that follows a newline should not be space delimited -
     /// it leads to an unexpected space before the content of a line.
     #[test]
-    fn test_raw_tokens_after_newlines() {
+    fn test_raw_tokens_with_newlines() {
         let output: String = format([Token::Newline, Token::Raw("!!!"), Token::Lit("42")]);
         assert_eq!(output, "\n!!! 42");
 
         let output: String = format([Token::SourceNewline, Token::Raw("!!!"), Token::Lit("42")]);
         assert_eq!(output, "\n!!! 42");
+
+        let output: String = format([Token::Raw("!!!"), Token::Newline]);
+        assert_eq!(output, "!!!\n");
+
+        let output: String = format([Token::Raw("!!!"), Token::SourceNewline]);
+        assert_eq!(output, "!!!\n");
+    }
+
+    /// An unhandled node that follows a newline should not be space delimited -
+    /// it leads to an unexpected space before the content of a line.
+    #[test]
+    fn test_newline_line_divider() {
+        let output: String = format([Token::Raw("!!!"), Token::Newline, Token::LineDivider('-')]);
+        assert_eq!(
+            output,
+            "!!!\n--------------------------------------------------------------------------------"
+        );
+
+        let output: String = format([Token::Raw("!!!"), Token::Newline, Token::LineDivider('=')]);
+        assert_eq!(
+            output,
+            "!!!\n================================================================================"
+        );
     }
 }

--- a/libtlafmt/src/renderer/snapshots/libtlafmt__renderer__indent__tests__let_in_record_literal.snap
+++ b/libtlafmt/src/renderer/snapshots/libtlafmt__renderer__indent__tests__let_in_record_literal.snap
@@ -1,0 +1,19 @@
+---
+source: libtlafmt/src/renderer/indent.rs
+expression: output
+---
+-------------------------------- MODULE Bananas --------------------------------
+AppendEntries(i, j) ==
+    /\ LET prevLogIndex == nextIndex[i][j] - 1
+            prevLogTerm == IF prevLogIndex > 0 THEN
+            log[i][prevLogIndex].term
+            ELSE
+            0
+        \* Send up to 1 entry, constrained by the end of the log.
+            lastEntry == Min({Len(log[i]), nextIndex[i][j]})
+            entries == SubSeq(log[i], nextIndex[i][j], lastEntry)
+        IN Send([mtype |-> AppendEntriesRequest,
+        mterm |-> currentTerm[i],
+        mprevLogIndex |-> prevLogIndex,
+        mdest |-> j])
+================================================================================

--- a/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
+++ b/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
@@ -97,13 +97,13 @@ LEMMA TypeCorrect == Spec => []TypeInv
 <1> USE Assumption DEF TypeInv
 <1>1. Init => TypeInv BY SMT DEF Init
 <1>2. TypeInv /\ [Next]_vars => TypeInv' BY SMT DEF Next, Put, Get, Wait, NotifyOther, vars
-<1>. QED BY <1>1, <1>2, PTL DEF Spec 
+<1>. QED BY <1>1, <1>2, PTL DEF Spec
 
 \* The naive thing to do is to check if the conjunct of TypeInv /\ Invariant
 \* is inductive.
 IInv ==
-    /\ TypeInv!2 
-    /\ TypeInv!3 
+    /\ TypeInv!2
+    /\ TypeInv!3
     /\ Invariant
     \* When the buffer is empty, a consumer will be added to the waitSet.
     \* However, this does not crate a deadlock, because at least one producer
@@ -118,7 +118,7 @@ THEOREM DeadlockFreedom == Spec => []Invariant
 <1>1. Init => IInv BY DEF Init
 <1>2. TypeInv /\ IInv /\ [Next]_vars => IInv' BY DEF TypeInv, Next, Put, Get, Wait, NotifyOther, vars
 <1>3. IInv => Invariant OBVIOUS
-<1>4. QED BY <1>1,<1>2,<1>3,PTL DEF Spec 
+<1>4. QED BY <1>1,<1>2,<1>3,PTL DEF Spec
 
 MCIInv == TypeInv!1 /\ IInv
 

--- a/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
+++ b/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
@@ -10,7 +10,7 @@ CONSTANTS Producers,   (* the (nonempty) set of producers                       
     Consumers,         (* the (nonempty) set of consumers                       *)
     BufCapacity        (* the maximum number of messages in the bounded buffer  *)
 
- ASSUME Assumption ==
+ASSUME Assumption ==
        /\ Producers # {}                      (* at least one producer *)
        /\ Consumers # {}                      (* at least one consumer *)
        /\ Producers \intersect Consumers = {} (* no thread is both consumer and producer *)
@@ -93,8 +93,8 @@ Spec == Init /\ [][Next]_vars
 \* though, that TypeInv itself won't imply Invariant though!  TypeInv alone
 \* does not help us prove Invariant.
 \* Luckily, TLAPS does not require us to decompose the proof into substeps.
- LEMMA TypeCorrect == Spec => [] TypeInv
- <1> USE Assumption DEF TypeInv
+LEMMA TypeCorrect == Spec => [] TypeInv
+<1> USE Assumption DEF TypeInv
 <1>1. Init => TypeInv BY SMT DEF Init
 <1>2. TypeInv /\ [Next]_vars => TypeInv' BY SMT DEF Next, Put, Get, Wait, NotifyOther, vars
 <1>. QED BY <1>1, <1>2, PTL DEF Spec 
@@ -114,7 +114,7 @@ IInv ==
     /\ Len(buffer) = BufCapacity => \E c \in Consumers: c \notin waitSet
 
 THEOREM DeadlockFreedom == Spec => [] Invariant
- <1> USE Assumption, TypeCorrect DEF IInv, Invariant
+<1> USE Assumption, TypeCorrect DEF IInv, Invariant
 <1>1. Init => IInv BY DEF Init
 <1>2. TypeInv /\ IInv /\ [Next]_vars => IInv' BY DEF TypeInv, Next, Put, Get, Wait, NotifyOther, vars
 <1>3. IInv => Invariant OBVIOUS

--- a/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
+++ b/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
@@ -133,7 +133,7 @@ FairSpec ==
     \* enabled. This is the basic case of fairness that rules out stuttering, i.e.,
     \* assert global progress.
     /\ \A t \in Producers:
-    WF_vars(Put(t, t))
+        WF_vars(Put(t, t))
     \* Stipulates that  Get  actions (consumers!) will eventually notify *all*
     \* waiting producers. In other words, given repeated  Get  actions (we don't
     \* care which consumer, thus, existential quantification), all waiting
@@ -145,13 +145,13 @@ FairSpec ==
     \* with the minor typo "in" instead of "notin", which happens to hold for
     \* configurations with at most two producers.
     /\ \A t \in Producers:
-    SF_vars(\E self \in Consumers: Get(self) /\ t \notin waitSet')
+        SF_vars(\E self \in Consumers: Get(self) /\ t \notin waitSet')
 
     \* See notes above (except swap "producer" with "consumer").
     /\ \A t \in Consumers:
-    WF_vars(Get(t))
+        WF_vars(Get(t))
     /\ \A t \in Consumers:
-    SF_vars(\E self \in Producers: Put(self, self) /\ t \notin waitSet')
+        SF_vars(\E self \in Producers: Put(self, self) /\ t \notin waitSet')
 
 (* All producers will continuously be serviced. For this to be violated,    *)
 (* ASSUME Cardinality(Producers) > 1 has to hold (a single producer cannot  *)

--- a/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
+++ b/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
@@ -93,7 +93,7 @@ Spec == Init /\ [][Next]_vars
 \* though, that TypeInv itself won't imply Invariant though!  TypeInv alone
 \* does not help us prove Invariant.
 \* Luckily, TLAPS does not require us to decompose the proof into substeps.
-LEMMA TypeCorrect == Spec => [] TypeInv
+LEMMA TypeCorrect == Spec => []TypeInv
 <1> USE Assumption DEF TypeInv
 <1>1. Init => TypeInv BY SMT DEF Init
 <1>2. TypeInv /\ [Next]_vars => TypeInv' BY SMT DEF Next, Put, Get, Wait, NotifyOther, vars
@@ -113,7 +113,7 @@ IInv ==
     \* but at least one consumer won't be in waitSet.
     /\ Len(buffer) = BufCapacity => \E c \in Consumers: c \notin waitSet
 
-THEOREM DeadlockFreedom == Spec => [] Invariant
+THEOREM DeadlockFreedom == Spec => []Invariant
 <1> USE Assumption, TypeCorrect DEF IInv, Invariant
 <1>1. Init => IInv BY DEF Init
 <1>2. TypeInv /\ IInv /\ [Next]_vars => IInv' BY DEF TypeInv, Next, Put, Get, Wait, NotifyOther, vars

--- a/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
+++ b/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
@@ -16,7 +16,7 @@ ASSUME Assumption ==
        /\ Producers \intersect Consumers = {} (* no thread is both consumer and producer *)
        /\ BufCapacity \in (Nat \ {0})         (* buffer capacity is at least 1 *)
 
- --------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 VARIABLES buffer, waitSet
 vars == << buffer, waitSet >>

--- a/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
+++ b/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
@@ -1,0 +1,163 @@
+---
+source: libtlafmt/src/lib.rs
+expression: output
+input_file: libtlafmt/tests/corpus/BlockingQueue.tla
+---
+----------------------------- MODULE BlockingQueue -----------------------------
+EXTENDS Naturals, Sequences, FiniteSets
+
+CONSTANTS Producers,   (* the (nonempty) set of producers                       *)
+    Consumers,         (* the (nonempty) set of consumers                       *)
+    BufCapacity        (* the maximum number of messages in the bounded buffer  *)
+
+ ASSUME Assumption ==
+       /\ Producers # {}                      (* at least one producer *)
+       /\ Consumers # {}                      (* at least one consumer *)
+       /\ Producers \intersect Consumers = {} (* no thread is both consumer and producer *)
+       /\ BufCapacity \in (Nat \ {0})         (* buffer capacity is at least 1 *)
+
+ --------------------------------------------------------------------------------
+
+VARIABLES buffer, waitSet
+vars == << buffer, waitSet >>
+
+RunningThreads ==(Producers \union Consumers) \ waitSet
+
+NotifyOther(Others) ==
+    IF waitSet \intersect Others /= {}
+    THEN \E t \in waitSet \intersect Others: waitSet' = waitSet \ {t}
+    ELSE UNCHANGED waitSet
+
+(* @see java.lang.Object#wait *)
+Wait(t) ==
+    /\ waitSet' = waitSet \union {t}
+    /\ UNCHANGED << buffer >>
+
+--------------------------------------------------------------------------------
+
+Put(t, d) ==
+    /\ t \notin waitSet
+    /\
+        \/
+            /\ Len(buffer) < BufCapacity
+            /\ buffer' = Append(buffer, d)
+            /\ NotifyOther(Consumers)
+        \/
+            /\ Len(buffer) = BufCapacity
+            /\ Wait(t)
+
+Get(t) ==
+    /\ t \notin waitSet
+    /\
+        \/
+            /\ buffer /= <<>>
+            /\ buffer' = Tail(buffer)
+            /\ NotifyOther(Producers)
+        \/
+            /\ buffer = <<>>
+            /\ Wait(t)
+
+--------------------------------------------------------------------------------
+
+(* Initially, the buffer is empty and no thread is waiting. *)
+Init ==
+    /\ buffer = <<>>
+    /\ waitSet = {}
+
+(* Then, pick a thread out of all running threads and have it do its thing. *)
+Next ==
+    \/ \E p \in Producers: Put(p, p) \* Add some data to buffer
+    \/ \E c \in Consumers: Get(c)
+
+--------------------------------------------------------------------------------
+
+(* TLA+ is untyped, thus lets verify the range of some values in each state. *)
+TypeInv ==
+    /\ buffer \in Seq(Producers)
+    /\ Len(buffer) \in 0..BufCapacity
+    /\ waitSet \in SUBSET(Producers \union Consumers)
+
+(* No Deadlock *)
+Invariant == waitSet /= (Producers \union Consumers)
+
+--------------------------------------------------------------------------------
+
+MySeq(P) == UNION {[1..n -> P]: n \in 0..BufCapacity}
+
+INSTANCE TLAPS
+
+Spec == Init /\ [][Next]_vars
+
+\* TypeInv will be a conjunct of the inductive invariant, so prove it inductive.
+\* An invariant I is inductive, iff Init => I and I /\ [Next]_vars => I. Note
+\* though, that TypeInv itself won't imply Invariant though!  TypeInv alone
+\* does not help us prove Invariant.
+\* Luckily, TLAPS does not require us to decompose the proof into substeps.
+ LEMMA TypeCorrect == Spec => [] TypeInv
+ <1> USE Assumption DEF TypeInv
+<1>1. Init => TypeInv BY SMT DEF Init
+<1>2. TypeInv /\ [Next]_vars => TypeInv' BY SMT DEF Next, Put, Get, Wait, NotifyOther, vars
+<1>. QED BY <1>1, <1>2, PTL DEF Spec 
+
+\* The naive thing to do is to check if the conjunct of TypeInv /\ Invariant
+\* is inductive.
+IInv ==
+    /\ TypeInv!2 
+    /\ TypeInv!3 
+    /\ Invariant
+    \* When the buffer is empty, a consumer will be added to the waitSet.
+    \* However, this does not crate a deadlock, because at least one producer
+    \* will not be in the waitSet.
+    /\ buffer = <<>> => \E p \in Producers: p \notin waitSet
+    \* Vice versa, when buffer is full, a producer will be added to waitSet,
+    \* but at least one consumer won't be in waitSet.
+    /\ Len(buffer) = BufCapacity => \E c \in Consumers: c \notin waitSet
+
+THEOREM DeadlockFreedom == Spec => [] Invariant
+ <1> USE Assumption, TypeCorrect DEF IInv, Invariant
+<1>1. Init => IInv BY DEF Init
+<1>2. TypeInv /\ IInv /\ [Next]_vars => IInv' BY DEF TypeInv, Next, Put, Get, Wait, NotifyOther, vars
+<1>3. IInv => Invariant OBVIOUS
+<1>4. QED BY <1>1,<1>2,<1>3,PTL DEF Spec 
+
+MCIInv == TypeInv!1 /\ IInv
+
+--------------------------------------------------------------------------------
+
+PutEnabled == \A p \in Producers: ENABLED Put(p, p)
+
+FairSpec ==
+    /\ Spec
+
+    \* Assert that producers take steps should their  Put  action be (continuously)
+    \* enabled. This is the basic case of fairness that rules out stuttering, i.e.,
+    \* assert global progress.
+    /\ \A t \in Producers:
+    WF_vars(Put(t, t))
+    \* Stipulates that  Get  actions (consumers!) will eventually notify *all*
+    \* waiting producers. In other words, given repeated  Get  actions (we don't
+    \* care which consumer, thus, existential quantification), all waiting
+    \* producers will eventually be notified.  Because  Get  actions are not
+    \* continuously enabled (the buffer might be empty), weak fairness is not
+    \* strong enough. Obviously, no real system scheduler implements such an
+    \* inefficient "policy".
+    \* This fairness constraint was initially proposed by Leslie Lamport, although
+    \* with the minor typo "in" instead of "notin", which happens to hold for
+    \* configurations with at most two producers.
+    /\ \A t \in Producers:
+    SF_vars(\E self \in Consumers: Get(self) /\ t \notin waitSet')
+
+    \* See notes above (except swap "producer" with "consumer").
+    /\ \A t \in Consumers:
+    WF_vars(Get(t))
+    /\ \A t \in Consumers:
+    SF_vars(\E self \in Producers: Put(self, self) /\ t \notin waitSet')
+
+(* All producers will continuously be serviced. For this to be violated,    *)
+(* ASSUME Cardinality(Producers) > 1 has to hold (a single producer cannot  *)
+(* starve itself).                                                          *)
+Starvation ==
+    /\ \A p \in Producers: []<>( <<Put(p, p)>>_vars )
+    /\ \A c \in Consumers: []<>( <<Get(c)>>_vars )
+
+================================================================================

--- a/libtlafmt/src/snapshots/libtlafmt__tests__corpus@differential_equations.tla.snap
+++ b/libtlafmt/src/snapshots/libtlafmt__tests__corpus@differential_equations.tla.snap
@@ -23,8 +23,8 @@ LOCAL IsDeriv(n, df, f) ==
         IF k = 0
         THEN g = f
         ELSE \E gg \in [DOMAIN f -> Real]:
-                /\ IsFirstDeriv(g, gg)
-                /\ IsD[k - 1, gg]
+            /\ IsFirstDeriv(g, gg)
+            /\ IsD[k - 1, gg]
     IN IsD[n, df]
 
 Integrate(D, a, b, InitVals) ==

--- a/libtlafmt/src/snapshots/libtlafmt__tests__corpus@health_circuit.tla.snap
+++ b/libtlafmt/src/snapshots/libtlafmt__tests__corpus@health_circuit.tla.snap
@@ -254,8 +254,8 @@ ExclusiveProbeState == \A t \in Threads:
 \* Eventually the circuit breaker is always "healthy", within the bounds of the
 \* model.
 EventuallyAlwaysHealthy == <>[](
-        \/ Counter_IsHealthy_Check         \* The circuit becomes healthy
-        \/ probe_windows = MaxProbeWindows \* Or the model deadlocks at state bounds
+    \/ Counter_IsHealthy_Check         \* The circuit becomes healthy
+    \/ probe_windows = MaxProbeWindows \* Or the model deadlocks at state bounds
 )
 
 ================================================================================

--- a/libtlafmt/src/snapshots/libtlafmt__tests__corpus@raft.tla.snap
+++ b/libtlafmt/src/snapshots/libtlafmt__tests__corpus@raft.tla.snap
@@ -203,11 +203,11 @@ RequestVote(i, j) ==
     /\ state[i] = Candidate
     /\ j \notin votesResponded[i]
     /\ Send([mtype |-> RequestVoteRequest,
-            mterm |-> currentTerm[i],
-            mlastLogTerm |-> LastTerm(log[i]),
-            mlastLogIndex |-> Len(log[i]),
-            msource |-> i,
-            mdest |-> j])
+        mterm |-> currentTerm[i],
+        mlastLogTerm |-> LastTerm(log[i]),
+        mlastLogIndex |-> Len(log[i]),
+        msource |-> i,
+        mdest |-> j])
     /\ UNCHANGED << serverVars, candidateVars, leaderVars, logVars >>
 
 \* Leader i sends j an AppendEntries request containing up to 1 entry.
@@ -225,16 +225,16 @@ AppendEntries(i, j) ==
             lastEntry == Min({Len(log[i]), nextIndex[i][j]})
             entries == SubSeq(log[i], nextIndex[i][j], lastEntry)
         IN Send([mtype |-> AppendEntriesRequest,
-                    mterm |-> currentTerm[i],
-                    mprevLogIndex |-> prevLogIndex,
-                    mprevLogTerm |-> prevLogTerm,
-                    mentries |-> entries,
-                    \* mlog is used as a history variable for the proof.
-                    \* It would not exist in a real implementation.
-                    mlog |-> log[i],
-                    mcommitIndex |-> Min({commitIndex[i], lastEntry}),
-                    msource |-> i,
-                    mdest |-> j])
+        mterm |-> currentTerm[i],
+        mprevLogIndex |-> prevLogIndex,
+        mprevLogTerm |-> prevLogTerm,
+        mentries |-> entries,
+        \* mlog is used as a history variable for the proof.
+        \* It would not exist in a real implementation.
+        mlog |-> log[i],
+        mcommitIndex |-> Min({commitIndex[i], lastEntry}),
+        msource |-> i,
+        mdest |-> j])
     /\ UNCHANGED << serverVars, candidateVars, leaderVars, logVars >>
 
 \* Candidate i transitions to leader.
@@ -243,15 +243,15 @@ BecomeLeader(i) ==
     /\ votesGranted[i] \in Quorum
     /\ state' = [state EXCEPT ![i] = Leader]
     /\ nextIndex' = [nextIndex EXCEPT ![i] =
-            [j \in Server |-> Len(log[i]) + 1]]
+        [j \in Server |-> Len(log[i]) + 1]]
     /\ matchIndex' = [matchIndex EXCEPT ![i] =
-            [j \in Server |-> 0]]
+        [j \in Server |-> 0]]
     /\ elections' = elections \union
         {[eterm |-> currentTerm[i],
-                eleader |-> i,
-                elog |-> log[i],
-                evotes |-> votesGranted[i],
-                evoterLog |-> voterLog[i]]}
+            eleader |-> i,
+            elog |-> log[i],
+            evotes |-> votesGranted[i],
+            evoterLog |-> voterLog[i]]}
     /\ UNCHANGED << messages, currentTerm, votedFor, candidateVars, logVars >>
 
 \* Leader i receives a client request to add v to the log.
@@ -272,10 +272,10 @@ AdvanceCommitIndex(i) ==
     /\ state[i] = Leader
     /\ LET \* The set of servers that agree up through index.
             Agree(index) == {i} \union {k \in Server:
-                    matchIndex[i][k] >= index}
+                matchIndex[i][k] >= index}
         \* The maximum indexes for which a quorum agrees
             agreeIndexes == {index \in 1..Len(log[i]):
-                    Agree(index) \in Quorum}
+                Agree(index) \in Quorum}
         \* New value for commitIndex'[i]
             newCommitIndex ==
                 IF
@@ -327,14 +327,14 @@ HandleRequestVoteResponse(i, j, m) ==
 \* they won't be looked at, so it doesn't matter.
     /\ m.mterm = currentTerm[i]
     /\ votesResponded' = [votesResponded EXCEPT ![i] =
-            votesResponded[i] \union {j}]
+        votesResponded[i] \union {j}]
     /\
         \/
             /\ m.mvoteGranted
             /\ votesGranted' = [votesGranted EXCEPT ![i] =
-                    votesGranted[i] \union {j}]
+                votesGranted[i] \union {j}]
             /\ voterLog' = [voterLog EXCEPT ![i] =
-                    voterLog[i] @@ (j :> m.mlog)]
+                voterLog[i] @@ (j :> m.mlog)]
         \/
             /\ ~m.mvoteGranted
             /\ UNCHANGED << votesGranted, voterLog >>

--- a/libtlafmt/src/token.rs
+++ b/libtlafmt/src/token.rs
@@ -1,7 +1,7 @@
 use tree_sitter::Node;
 
 /// Positional metadata for a token.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum Position {
     /// The absolute position where this token appears in the source / input
     /// spec.
@@ -39,7 +39,7 @@ impl From<&Node<'_>> for Position {
 }
 
 /// The formatter token to be rendered.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Token<'a> {
     /// A raw string to print.
     ///

--- a/libtlafmt/src/token.rs
+++ b/libtlafmt/src/token.rs
@@ -347,9 +347,12 @@ impl Token<'_> {
 
             // Chained liveness tokens are not space delimited, nor should there
             // be a space before the [Next] portion in `<>[][Next]_vars`.
+            //
+            // Likewise a THEOREM == Spec => []Op should not be space delimited
+            // between [] and the ident.
             (
                 Token::Eventually | Token::Always,
-                Token::Eventually | Token::Always | Token::StepOrStutter(_),
+                Token::Eventually | Token::Always | Token::StepOrStutter(_) | Token::Ident(_),
             ) => 0,
 
             // Fairness bounds must not be space delimited.

--- a/libtlafmt/src/token.rs
+++ b/libtlafmt/src/token.rs
@@ -300,6 +300,7 @@ impl Token<'_> {
             // Newlines are never automatically followed by whitespace.
             (Token::Newline | Token::SourceNewline, _) => 0,
 
+            (Token::Raw(_), Token::Newline | Token::SourceNewline) => 0,
             (Token::Raw(_), _) => 1,
             (_, Token::Raw(_)) => 1,
 

--- a/libtlafmt/src/token.rs
+++ b/libtlafmt/src/token.rs
@@ -301,6 +301,7 @@ impl Token<'_> {
             (Token::Newline | Token::SourceNewline, _) => 0,
 
             (Token::Raw(_), Token::Newline | Token::SourceNewline) => 0,
+            (Token::Raw(s), _) if s.ends_with("\n") => 0,
             (Token::Raw(_), _) => 1,
             (_, Token::Raw(_)) => 1,
 

--- a/libtlafmt/src/token.rs
+++ b/libtlafmt/src/token.rs
@@ -297,12 +297,14 @@ impl Token<'_> {
         match (self, next) {
             (_, Token::ModuleHeader(_)) => 0,
 
+            // Newlines are never automatically followed by whitespace.
+            (Token::Newline | Token::SourceNewline, _) => 0,
+
             (Token::Raw(_), _) => 1,
             (_, Token::Raw(_)) => 1,
 
             // Comments with explicit whitespace padding render the provided
-            // amount of space, but never after newlines.
-            (Token::Newline | Token::SourceNewline, Token::Comment(..)) => 0,
+            // amount of space.
             (_, Token::Comment(_, Position::Padding(v))) => *v,
 
             // These tokens can never be followed by a space, irrespective of
@@ -378,9 +380,6 @@ impl Token<'_> {
             {
                 0
             }
-
-            // Newlines are never automatically followed by whitespace.
-            (Token::SourceNewline | Token::Newline, _) => 0,
 
             // All other tokens can be delimited by whitespace.
             _ => 1,

--- a/libtlafmt/tests/corpus/BlockingQueue.tla
+++ b/libtlafmt/tests/corpus/BlockingQueue.tla
@@ -1,0 +1,147 @@
+--------------------------- MODULE BlockingQueue ---------------------------
+EXTENDS Naturals, Sequences, FiniteSets
+
+CONSTANTS Producers,   (* the (nonempty) set of producers                       *)
+          Consumers,   (* the (nonempty) set of consumers                       *)
+          BufCapacity  (* the maximum number of messages in the bounded buffer  *)
+
+ASSUME Assumption ==
+       /\ Producers # {}                      (* at least one producer *)
+       /\ Consumers # {}                      (* at least one consumer *)
+       /\ Producers \intersect Consumers = {} (* no thread is both consumer and producer *)
+       /\ BufCapacity \in (Nat \ {0})         (* buffer capacity is at least 1 *)
+
+-----------------------------------------------------------------------------
+
+VARIABLES buffer, waitSet
+vars == <<buffer, waitSet>>
+
+RunningThreads == (Producers \cup Consumers) \ waitSet
+
+NotifyOther(Others) ==
+    IF waitSet \cap Others # {}
+    THEN \E t \in waitSet \cap Others : waitSet' = waitSet \ {t}
+    ELSE UNCHANGED waitSet
+
+(* @see java.lang.Object#wait *)
+Wait(t) == /\ waitSet' = waitSet \cup {t}
+           /\ UNCHANGED <<buffer>>
+
+-----------------------------------------------------------------------------
+
+Put(t, d) ==
+/\ t \notin waitSet
+/\ \/ /\ Len(buffer) < BufCapacity
+      /\ buffer' = Append(buffer, d)
+      /\ NotifyOther(Consumers)
+   \/ /\ Len(buffer) = BufCapacity
+      /\ Wait(t)
+
+Get(t) ==
+/\ t \notin waitSet
+/\ \/ /\ buffer # <<>>
+      /\ buffer' = Tail(buffer)
+      /\ NotifyOther(Producers)
+   \/ /\ buffer = <<>>
+      /\ Wait(t)
+
+-----------------------------------------------------------------------------
+
+(* Initially, the buffer is empty and no thread is waiting. *)
+Init == /\ buffer = <<>>
+        /\ waitSet = {}
+
+(* Then, pick a thread out of all running threads and have it do its thing. *)
+Next == \/ \E p \in Producers: Put(p, p) \* Add some data to buffer
+        \/ \E c \in Consumers: Get(c)
+
+-----------------------------------------------------------------------------
+
+(* TLA+ is untyped, thus lets verify the range of some values in each state. *)
+TypeInv == /\ buffer \in Seq(Producers)
+           /\ Len(buffer) \in 0..BufCapacity
+           /\ waitSet \in SUBSET (Producers \cup Consumers)
+
+(* No Deadlock *)
+Invariant == waitSet # (Producers \cup Consumers)
+
+-----------------------------------------------------------------------------
+
+MySeq(P) == UNION {[1..n -> P] : n \in 0..BufCapacity}
+
+INSTANCE TLAPS
+
+Spec == Init /\ [][Next]_vars
+
+\* TypeInv will be a conjunct of the inductive invariant, so prove it inductive.
+\* An invariant I is inductive, iff Init => I and I /\ [Next]_vars => I. Note
+\* though, that TypeInv itself won't imply Invariant though!  TypeInv alone
+\* does not help us prove Invariant.
+\* Luckily, TLAPS does not require us to decompose the proof into substeps.
+LEMMA TypeCorrect == Spec => []TypeInv
+<1> USE Assumption DEF TypeInv
+<1>1. Init => TypeInv BY SMT DEF Init
+<1>2. TypeInv /\ [Next]_vars => TypeInv' BY SMT DEF Next, Put, Get, Wait, NotifyOther, vars
+<1>. QED BY <1>1, <1>2, PTL DEF Spec
+
+\* The naive thing to do is to check if the conjunct of TypeInv /\ Invariant
+\* is inductive.
+IInv == /\ TypeInv!2
+        /\ TypeInv!3
+        /\ Invariant
+        \* When the buffer is empty, a consumer will be added to the waitSet.
+        \* However, this does not crate a deadlock, because at least one producer
+        \* will not be in the waitSet.
+        /\ buffer = <<>> => \E p \in Producers : p \notin waitSet
+        \* Vice versa, when buffer is full, a producer will be added to waitSet,
+        \* but at least one consumer won't be in waitSet.
+        /\ Len(buffer) = BufCapacity => \E c \in Consumers : c \notin waitSet
+
+THEOREM DeadlockFreedom == Spec => []Invariant
+<1> USE Assumption, TypeCorrect DEF IInv, Invariant
+<1>1. Init => IInv BY DEF Init
+<1>2. TypeInv /\ IInv /\ [Next]_vars => IInv' BY DEF TypeInv, Next, Put, Get, Wait, NotifyOther, vars
+<1>3. IInv => Invariant OBVIOUS
+<1>4. QED BY <1>1,<1>2,<1>3,PTL DEF Spec
+
+MCIInv == TypeInv!1 /\ IInv
+
+-----------------------------------------------------------------------------
+
+PutEnabled == \A p \in Producers : ENABLED Put(p, p)
+
+FairSpec ==
+    /\ Spec
+
+    \* Assert that producers take steps should their  Put  action be (continuously)
+    \* enabled. This is the basic case of fairness that rules out stuttering, i.e.,
+    \* assert global progress.
+    /\ \A t \in Producers:
+            WF_vars(Put(t,t))
+    \* Stipulates that  Get  actions (consumers!) will eventually notify *all*
+    \* waiting producers. In other words, given repeated  Get  actions (we don't
+    \* care which consumer, thus, existential quantification), all waiting
+    \* producers will eventually be notified.  Because  Get  actions are not
+    \* continuously enabled (the buffer might be empty), weak fairness is not
+    \* strong enough. Obviously, no real system scheduler implements such an
+    \* inefficient "policy".
+    \* This fairness constraint was initially proposed by Leslie Lamport, although
+    \* with the minor typo "in" instead of "notin", which happens to hold for
+    \* configurations with at most two producers.
+    /\ \A t \in Producers:
+            SF_vars(\E self \in Consumers: Get(self) /\ t \notin waitSet')
+
+    \* See notes above (except swap "producer" with "consumer").
+    /\ \A t \in Consumers:
+            WF_vars(Get(t))
+    /\ \A t \in Consumers:
+            SF_vars(\E self \in Producers: Put(self, self) /\ t \notin waitSet')
+
+(* All producers will continuously be serviced. For this to be violated,    *)
+(* ASSUME Cardinality(Producers) > 1 has to hold (a single producer cannot  *)
+(* starve itself).                                                          *)
+Starvation ==
+    /\ \A p \in Producers: []<>(<<Put(p, p)>>_vars)
+    /\ \A c \in Consumers: []<>(<<Get(c)>>_vars)
+
+=============================================================================


### PR DESCRIPTION
This adds the [BlockingQueue.tla](https://github.com/lemmy/BlockingQueue/blob/main/BlockingQueue.tla) spec to the test corpus, and fixes a bunch of issues it highlighted. Some issues are minor / spacing, but the lack of indentation for bounded quantifications led to spec breakage.

Closes https://github.com/domodwyer/tlafmt/issues/25.

---

* test: include BlockingQueue in corpus (e7cf442)
      
      This adds the BlockingQueue.tla spec[1] by @lemmy in the test corpus,
      which immediately fails tests due to malformed handling of the FairSpec
      operator.
      
      There's also a number of smaller bugs in the formatting of this file,
      which I've extracted into specific test cases.
      
      [1]: https://github.com/lemmy/BlockingQueue/blob/d2e0dc12c72fa5d5721cf08bbc1e3b9e7cde309f/BlockingQueue.tla

* fix: newline -> raw token delimited with space (0c4c462)
      
      Removes the single space character that started a new line when the
      first token was a Token::Raw.

* fix: space delimiter between []Identifier (6cd4264)
      
      Prevent the "always" token and an identifier from being delimited by
      whitespace.

* fix: raw token / newline delimited by whitespace (9feccc5)
      
      Token::Raw followed by a newline would leave a trailing space after the
      raw token.

* fix: whitespace after raw token with newline (258e5aa)
      
      Raw tokens that end with newlines would have a space inserted before the
      next token, causing the next token to be weirdly spaced.

* feat: token indentation rewriter (9630577)
      
      Prevents excessive indentation from one line to the next.
      
      This adds a long desired post-processing pass over the format token list
      before rendering to adjust indentation of nested blocks when all tokens
      within the block are at 2 or more levels deeper than the previous line's
      indentation ("excessively indented").
      
      This pass results in more consistent indentation, while accounting for
      tokens that appear "late" in the block that cause it to be properly
      indented (a token eventually appears at N+1, not just N+2 or more).

* fix: indent bounded quantifications (f6f8901)
      
      This fixes missing indentation, which shows up in the BlockingQueue.tla
      test corpus which resulted in a broken spec being rendered.