### PR TITLE
docs(readme): tweaks but respects input spec style

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Check out the `--help` text too.
 
 ## Style
 
+This formatter doesn't aim to enforce a prescriptive, universal style across the
+whole spec. Instead it aims to improve consistency by making small changes,
+respecting the general style of the input spec.
+
 Formatting is being iterated on - please [report] any undesirable rendering as
 an issue.
 


### PR DESCRIPTION
Update the readme to describe the kind of changes this formatter makes.

---      

* docs(readme): tweaks but respects input spec style (40e3366)
      
      This describes a goal of this formatter I realised I hadn't documented.