### PR TITLE
fix: spacing between op == (parens)

### DIFF
--- a/libtlafmt/src/renderer/mod.rs
+++ b/libtlafmt/src/renderer/mod.rs
@@ -557,7 +557,7 @@ mod tests {
             (Token::AngleOpen, "<< "), // Extra space
         ];
 
-        let eq = [(Token::Eq, "="), (Token::NotEq, "/=")];
+        let eq = [(Token::Eq, "="), (Token::NotEq, "/="), (Token::Eq2, "==")];
 
         for (paren, p_symbol) in parens {
             for (eq, e_symbol) in &eq {

--- a/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
+++ b/libtlafmt/src/snapshots/libtlafmt__tests__corpus@BlockingQueue.tla.snap
@@ -21,7 +21,7 @@ ASSUME Assumption ==
 VARIABLES buffer, waitSet
 vars == << buffer, waitSet >>
 
-RunningThreads ==(Producers \union Consumers) \ waitSet
+RunningThreads == (Producers \union Consumers) \ waitSet
 
 NotifyOther(Others) ==
     IF waitSet \intersect Others /= {}

--- a/libtlafmt/src/token.rs
+++ b/libtlafmt/src/token.rs
@@ -364,9 +364,10 @@ impl Token<'_> {
             (Token::StepOrStutter(_), _) => 0,
 
             // Eq followed by parens.
-            (Token::Eq | Token::NotEq, Token::ParenOpen | Token::SquareOpen | Token::AngleOpen) => {
-                1
-            }
+            (
+                Token::Eq | Token::Eq2 | Token::NotEq,
+                Token::ParenOpen | Token::SquareOpen | Token::AngleOpen,
+            ) => 1,
 
             // No space between this token and the listed tokens.
             _ if matches!(


### PR DESCRIPTION
I just spotted another spacing issue in BlockingQueue.tla.

---

* fix: spacing between op == (parens) (9de627a)
      
      Previously this would render as:
      
          Op ==(body)
      
      Now:
      
          Op == (body)