### PR TITLE
ci: no force reinstall cargo fuzz

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install cargo-fuzz
         if: steps.cache-cargo-fuzz.outputs.cache-hit != 'true'
-        run: cargo install -f cargo-fuzz --all-features
+        run: cargo install cargo-fuzz --all-features
 
       - name: Seed fuzzing corpus from test corpus
         run: >


### PR DESCRIPTION
🤦 

---

* ci: no force reinstall cargo fuzz (989fae3)
      
      The continuous fuzzing CI job caches the cargo state to avoid
      reinstalling cargo fuzz each time, but the fallback command was forcing
      a reinstall anyway.