### PR TITLE
ci: continious fuzzing workflow fixes

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -47,6 +47,13 @@ jobs:
           key: fuzz-corpus-e2e
           path: libtlafmt/fuzz/corpus/e2e
 
+      - name: Cache fuzz target dir
+        id: target-dir
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-fuzz-target-dir
+          path: libtlafmt/fuzz/target
+
       - name: Run fuzzer
         id: fuzz
         run: >

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,7 +31,7 @@ jobs:
           path: /cargo
 
       - name: Install cargo-fuzz
-        if: steps.cache-cargo-fuzz.outputs.cache-hit != 'true'
+        if: steps.cargo-dir.outputs.cache-hit != 'true'
         run: cargo install cargo-fuzz --all-features
 
       - name: Seed fuzzing corpus from test corpus

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Seed fuzzing corpus from test corpus
         run: >
           mkdir -p libtlafmt/fuzz/corpus/e2e;
-          cp libtlafmt/tests/corpus/* libtlafmt/fuzz/corpus
+          cp libtlafmt/tests/corpus/* libtlafmt/fuzz/corpus/e2e
 
       - name: Cache corpus
         id: cache-fuzz-corpus

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -30,13 +30,6 @@ jobs:
           key: ${{ runner.os }}-cargo-nightly
           path: /cargo
 
-      - name: Cache cargo-fuzz
-        id: cache-cargo-fuzz
-        uses: actions/cache@v4
-        with:
-          key: ${{ runner.os }}-cargo-fuzz
-          path: /usr/local/cargo/bin/cargo-fuzz
-
       - name: Install cargo-fuzz
         if: steps.cache-cargo-fuzz.outputs.cache-hit != 'true'
         run: cargo install cargo-fuzz --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
         with:
           generate_release_notes: true
 


### PR DESCRIPTION
Speed up the continious fuzzing workflow and fix seeding the fuzz corpus from the test corpus.

---

* ci: remove unused cache directive (9e18c25)
      
      The cargo fuzz binary lives in /cargo, and is cached sufficiently as
      part of the cargo dir cache already.

* ci(fix): seeding fuzz corpus uses incorrect path (e432cc1)
      
      This was copying the test corpus into a directory that wasn't used by
      the e2e fuzzer.

* ci: cache fuzz target dir (ae7994b)
      
      Reduce the amount of time spent building the fuzz target by caching the
      incremental compilation artefacts.

* ci: pin non-github action to hash (ca2a4cf)
      
      This avoids tags being repointed if the action is compromised.

* ci(fix): cache conditional cargo-fuzz install (78c826c)
      
      The cache key being used for the conditional install of cargo-fuzz was
      incorrect.