### PR TITLE
fix: block comment indentation

### DIFF
--- a/libtlafmt/src/ast_format/comment.rs
+++ b/libtlafmt/src/ast_format/comment.rs
@@ -21,7 +21,7 @@ where
     //
     // If a comment was not indented, it should be rendered without
     // formatter-added indentation below this branch.
-    if def.kind() != "block_comment" && def.start_position().column != 0 {
+    if def.start_position().column != 0 {
         writer.push(Token::Comment(get_str(&def, input), Position::from(&def)))?;
         return Ok(());
     }
@@ -87,6 +87,19 @@ S (* are great
     dont
     you think*)
 ) == 42
+====="
+        );
+    }
+
+    #[test]
+    fn test_block() {
+        assert_rewrite!(
+            r"
+---- MODULE Bananas ------
+X ==
+    /\ A = 42
+    (* There's a block comment here *)
+    /\ B = A
 ====="
         );
     }

--- a/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__comment__tests__block.snap
+++ b/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__comment__tests__block.snap
@@ -1,0 +1,10 @@
+---
+source: libtlafmt/src/ast_format/comment.rs
+expression: output
+---
+-------------------------------- MODULE Bananas --------------------------------
+X ==
+    /\ A = 42
+    (* There's a block comment here *)
+    /\ B = A
+================================================================================


### PR DESCRIPTION
Block comments were unpleasantly indented within a block.

---

* fix: block comment indentation (6c62813)
      
      Prior to this commit, a block comment could be incorrectly indented:
      
          X ==
              /\ A = 42
              (* There's a block comment here *)
              /\ B = A
      
      Would be formatted as:
      
          X ==
              /\ A = 42
          (* There's a block comment here *)
              /\ B = A
      
      The formatter now outputs the same as the example input.