### PR TITLE
fix: comment padding after raw token

### DIFF
--- a/libtlafmt/src/renderer/comment.rs
+++ b/libtlafmt/src/renderer/comment.rs
@@ -136,7 +136,9 @@ fn process_candidates(
 
     for (candidate_idx, (buf_idx, ..)) in candidates.iter().enumerate() {
         match &mut buf[*buf_idx] {
-            (Token::Comment(_, pos), _) => *pos = Position::Padding(new_col - lines[candidate_idx]),
+            (Token::Comment(_, pos), _) => {
+                *pos = Position::Relative(new_col - lines[candidate_idx])
+            }
             _ => unreachable!(),
         }
     }

--- a/libtlafmt/src/renderer/mod.rs
+++ b/libtlafmt/src/renderer/mod.rs
@@ -681,4 +681,19 @@ mod tests {
             "!!!\n================================================================================"
         );
     }
+
+    /// Raw tokens followed by relatively spaced comments should respect the
+    /// relative spacing.
+    #[test]
+    fn test_raw_token_relative_comment_positioning() {
+        let output: String = format([
+            Token::Newline,
+            Token::Raw("!!!"),
+            Token::Comment(r"(* 42 *)", crate::token::Position::Relative(42)),
+        ]);
+        assert_eq!(
+            output,
+            "\n!!!                                          (* 42 *)"
+        );
+    }
 }

--- a/libtlafmt/src/token.rs
+++ b/libtlafmt/src/token.rs
@@ -9,7 +9,7 @@ pub(crate) enum Position {
 
     /// The amount of padding whitespace to precede to this token (relative
     /// positioning w.r.t previous token).
-    Padding(usize),
+    Relative(usize),
 }
 
 impl Position {
@@ -310,13 +310,14 @@ impl Token<'_> {
             (Token::Newline | Token::SourceNewline, _) => 0,
 
             (Token::Raw(_), Token::Newline | Token::SourceNewline) => 0,
+            (Token::Raw(_), Token::Comment(_, Position::Relative(v))) => *v,
             (Token::Raw(s), _) if s.ends_with("\n") => 0,
             (Token::Raw(_), _) => 1,
             (_, Token::Raw(_)) => 1,
 
             // Comments with explicit whitespace padding render the provided
             // amount of space.
-            (_, Token::Comment(_, Position::Padding(v))) => *v,
+            (_, Token::Comment(_, Position::Relative(v))) => *v,
 
             // These tokens can never be followed by a space, irrespective of
             // the next token.

--- a/libtlafmt/tests/corpus/InnerFIFO.tla
+++ b/libtlafmt/tests/corpus/InnerFIFO.tla
@@ -1,0 +1,40 @@
+---------------------------- MODULE InnerFIFO -------------------------------
+EXTENDS Naturals, Sequences
+CONSTANT Message
+VARIABLES in, out, q
+InChan  == INSTANCE Channel WITH Data <- Message, chan <- in
+OutChan == INSTANCE Channel WITH Data <- Message, chan <- out
+-----------------------------------------------------------------------------
+Init == /\ InChan!Init
+        /\ OutChan!Init
+        /\ q = << >>
+
+TypeInvariant  ==  /\ InChan!TypeInvariant
+                   /\ OutChan!TypeInvariant
+                   /\ q \in Seq(Message)
+
+SSend(msg)  ==  /\ InChan!Send(msg) \* Send msg on channel `in'.
+                /\ UNCHANGED <<out, q>>
+
+BufRcv == /\ InChan!Rcv              \* Receive message from channel `in'.
+          /\ q' = Append(q, in.val)  \*   and append it to tail of q.
+          /\ UNCHANGED out
+
+BufSend == /\ q # << >>               \* Enabled only if q is nonempty.
+           /\ OutChan!Send(Head(q))   \* Send Head(q) on channel `out'
+           /\ q' = Tail(q)            \*   and remove it from q.
+           /\ UNCHANGED in
+
+RRcv == /\ OutChan!Rcv          \* Receive message from channel `out'.
+        /\ UNCHANGED <<in, q>>
+
+Next == \/ \E msg \in Message : SSend(msg)
+        \/ BufRcv
+        \/ BufSend
+        \/ RRcv 
+
+Spec == Init /\ [][Next]_<<in, out, q>>
+-----------------------------------------------------------------------------
+THEOREM Spec => []TypeInvariant
+=============================================================================
+

--- a/libtlafmt/tests/snapshots/format__corpus@InnerFIFO.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@InnerFIFO.tla.snap
@@ -1,0 +1,51 @@
+---
+source: libtlafmt/tests/format.rs
+expression: output
+input_file: libtlafmt/tests/corpus/InnerFIFO.tla
+---
+------------------------------- MODULE InnerFIFO -------------------------------
+EXTENDS Naturals, Sequences
+CONSTANT Message
+VARIABLES in, out, q
+InChan  == INSTANCE Channel WITH Data <- Message, chan <- in
+OutChan == INSTANCE Channel WITH Data <- Message, chan <- out
+--------------------------------------------------------------------------------
+Init ==
+    /\ InChan!Init
+    /\ OutChan!Init
+    /\ q = <<>>
+
+TypeInvariant ==
+    /\ InChan!TypeInvariant
+    /\ OutChan!TypeInvariant
+    /\ q \in Seq(Message)
+
+SSend(msg) ==
+    /\ InChan!Send(msg) \* Send msg on channel `in'.
+    /\ UNCHANGED << out, q >>
+
+BufRcv ==
+    /\ InChan!Rcv                    \* Receive message from channel `in'.
+    /\ q' = Append(q, in.val)        \*   and append it to tail of q.
+    /\ UNCHANGED out
+
+BufSend ==
+    /\ q /= <<>>                      \* Enabled only if q is nonempty.
+    /\ OutChan!Send(Head(q))          \* Send Head(q) on channel `out'
+    /\ q' = Tail(q)                   \*   and remove it from q.
+    /\ UNCHANGED in
+
+RRcv ==
+    /\ OutChan!Rcv \* Receive message from channel `out'.
+    /\ UNCHANGED << in, q >>
+
+Next ==
+    \/ \E msg \in Message: SSend(msg)
+    \/ BufRcv
+    \/ BufSend
+    \/ RRcv
+
+Spec == Init /\ [][Next]_<< in, out, q >>
+--------------------------------------------------------------------------------
+THEOREM Spec => []TypeInvariant
+================================================================================


### PR DESCRIPTION
Prevent breakage of a spec from the TLA Examples.

---

* fix: comment padding after raw token (d6d25b3)
      
      Respect the amount of relative positional padding for comments following
      raw tokens.