### PR TITLE
ci: cache build state using lockfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,14 +25,16 @@ jobs:
         id: cargo-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-cargo
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo
           path: /cargo
 
       - name: Cache target dir
         id: target-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-target-dir
+          key: ${{ runner.os }}-target-dir-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-target-dir
           path: target
 
       - name: dev

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,7 +27,8 @@ jobs:
         id: cargo-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-cargo-nightly
+          key: ${{ runner.os }}-cargo-nightly-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('libtlafmt/fuzz/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-nightly
           path: /cargo
 
       - name: Install cargo-fuzz
@@ -51,7 +52,8 @@ jobs:
         id: target-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-fuzz-target-dir
+          key: ${{ runner.os }}-fuzz-target-dir-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('libtlafmt/fuzz/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-fuzz-target-dir
           path: libtlafmt/fuzz/target
 
       - name: Run fuzzer

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,14 +25,16 @@ jobs:
         id: cargo-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-cargo
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo
           path: /cargo
 
       - name: Cache target dir
         id: target-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-target-dir
+          key: ${{ runner.os }}-target-dir-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-target-dir
           path: target
 
       - name: rustup add components

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,16 @@ jobs:
         id: cargo-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-cargo
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo
           path: /cargo
 
       - name: Cache target dir
         id: target-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-target-dir
+          key: ${{ runner.os }}-target-dir-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-target-dir
           path: target
 
       - name: cargo test


### PR DESCRIPTION
⏩ 

---

* ci: cache build state using lockfile (ca9f32c)
      
      Use the lockfile hash in the cache key, and attempt to fetch a
      recent-ish cache if the specific dependencies are not yet cached.