### PR TITLE
test: no comment re-indent for re-indented block

### DIFF
--- a/libtlafmt/src/renderer/comment.rs
+++ b/libtlafmt/src/renderer/comment.rs
@@ -502,6 +502,47 @@ SetToSeqs == UNION {{x \in [1 -> set]:
     "
             );
         }
+
+        /// Scenario 9:
+        ///
+        /// Comments which are inline with statements that are re-indented.
+        ///
+        /// These comments are NOT re-indented, which while it's desirable for
+        /// this block, it would cause the comments in
+        /// [test_comment_only_lines_8] and [test_comment_only_lines_4] to be
+        /// repositioned in a way that looks unnatural.
+        ///
+        /// By leaving them "where they are" it is at least not surprising, and
+        /// easy to correct (the reverse is not "fixable" by re-indenting the
+        /// source).
+        ///
+        /// This renders like:
+        ///
+        /// ```text
+        /// TypeOK ==
+        ///     /\ X = 42
+        ///               \* Platanos
+        ///               \* Platanos
+        ///     /\ Y = 24
+        /// ```
+        ///
+        /// If the positions of the surrounding nodes were retained at the
+        /// `Token` level, it could be determined that the comment needs
+        /// rewriting to be inline with the new position of those nodes, which
+        /// would allow this to be formatted.
+        #[test]
+        fn test_comment_only_lines_9() {
+            assert_rewrite!(
+                r"
+---- MODULE bananas ----
+TypeOK ==     /\ X = 42
+              \* Platanos
+              \* Platanos
+              /\ Y = 24
+====
+    "
+            );
+        }
     }
 
     /// A test case discovered through fuzzing where the input string contains a

--- a/libtlafmt/src/renderer/snapshots/libtlafmt__renderer__comment__tests__comment_only_lines__comment_only_lines_9.snap
+++ b/libtlafmt/src/renderer/snapshots/libtlafmt__renderer__comment__tests__comment_only_lines__comment_only_lines_9.snap
@@ -1,0 +1,11 @@
+---
+source: libtlafmt/src/renderer/comment.rs
+expression: output
+---
+-------------------------------- MODULE bananas --------------------------------
+TypeOK ==
+    /\ X = 42
+              \* Platanos
+              \* Platanos
+    /\ Y = 24
+================================================================================


### PR DESCRIPTION
For https://github.com/domodwyer/tlafmt/pull/47

---

* test: no comment re-indent for re-indented block (87a15b4)
      
      This test covers and explains why comments on comment only lines will be
      left "floating" in their original position after a block is re-indented.
      
      In the future this can be improved by passing the original token
      positions down to the renderer level, so the comment alignment can
      decide if the comment was previously aligned and choose to align it
      after the block re-indentation.