### PR TITLE
fix: do not respect indent of newlines for rewrite

### DIFF
--- a/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__newline_indent_non_list.snap
+++ b/libtlafmt/src/ast_format/snapshots/libtlafmt__ast_format__node__tests__newline_indent_non_list.snap
@@ -6,8 +6,8 @@ expression: output
 NoVal ==
     CHOOSE v:
 
-    v \notin
-    Val
+        v \notin
+        Val
 
 \* Bananas are good
 Store ==

--- a/libtlafmt/src/renderer/indent.rs
+++ b/libtlafmt/src/renderer/indent.rs
@@ -122,7 +122,7 @@ fn recurse(buf: &mut [(Token<'_>, Indent)]) -> usize {
         // token was not a newline.
         let last = last_was_newline;
         last_was_newline = matches!(buf[i].0, Token::Newline | Token::SourceNewline);
-        if !last {
+        if !last || last_was_newline {
             i += 1;
             continue;
         }
@@ -383,6 +383,23 @@ AppendEntries(i, j) ==
                 mterm          |-> currentTerm[i],
                 mprevLogIndex  |-> prevLogIndex,
                 mdest          |-> j])
+====
+"
+        )
+    }
+
+    #[test]
+    fn test_conj_list_in_bounded_quantification_then_comment() {
+        assert_rewrite!(
+            r"
+---- MODULE B ----
+ClientRejectsBadMetadata ==
+    /\ BadKey \notin sigs
+    /\ \A f \in target_files:
+        /\ BadKey \notin f.sigs
+        /\ f.version /= InvalidVersion
+
+\* This repro only happens when there's a comment here
 ====
 "
         )

--- a/libtlafmt/src/renderer/snapshots/libtlafmt__renderer__indent__tests__conj_list_in_bounded_quantification_then_comment.snap
+++ b/libtlafmt/src/renderer/snapshots/libtlafmt__renderer__indent__tests__conj_list_in_bounded_quantification_then_comment.snap
@@ -1,0 +1,13 @@
+---
+source: libtlafmt/src/renderer/indent.rs
+expression: output
+---
+----------------------------------- MODULE B -----------------------------------
+ClientRejectsBadMetadata ==
+    /\ BadKey \notin sigs
+    /\ \A f \in target_files:
+        /\ BadKey \notin f.sigs
+        /\ f.version /= InvalidVersion
+        
+\* This repro only happens when there's a comment here
+================================================================================

--- a/libtlafmt/tests/snapshots/format__corpus@ACP_SB.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@ACP_SB.tla.snap
@@ -335,8 +335,8 @@ Spec == Init /\ [][progN]_<< coordinator, participant >> /\ fairness
 
 \* All participants that decide reach the same decision
 AC1 == [] \A i, j \in participants:
-        \/ participant[i].decision /= commit
-        \/ participant[j].decision /= abort
+    \/ participant[i].decision /= commit
+    \/ participant[j].decision /= abort
     
 \* If any participant decides commit, then all participants must have votes YES
 AC2 == []((\E i \in participants: participant[i].decision = commit)

--- a/libtlafmt/tests/snapshots/format__corpus@BufferedRandomAccessFile.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@BufferedRandomAccessFile.tla.snap
@@ -191,8 +191,8 @@ Read(data) ==
                 numToRead == Min(ArrayLen(data), numReadableWithoutSeeking)
                 buffOff == curr - lo
             IN
-                /\ data = ArraySlice(buff, buffOff, buffOff + numToRead)
-                /\ curr' = curr + numToRead
+            /\ data = ArraySlice(buff, buffOff, buffOff + numToRead)
+            /\ curr' = curr + numToRead
         /\ UNCHANGED << buff, dirty, diskPos, file_content, file_pointer, length, lo >>
     
 \* The `write()` method is composed of repeated calls to `writeAtMost()`, so

--- a/libtlafmt/tests/snapshots/format__corpus@CheckpointCoordination.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@CheckpointCoordination.tla.snap
@@ -199,23 +199,23 @@ SafetyInvariant ==
                     /\ CurrentLease[Leader].node = n
                     \* Two nodes can't take a checkpoint simultaneously
     /\ \A n1, n2 \in Node:
-        /\ (CanTakeCheckpoint[n1] /\ CanTakeCheckpoint[n2]) =>
-            /\ n1 = n2
-        /\ (IsTakingCheckpoint[n1] /\ IsTakingCheckpoint[n2]) =>
-            /\ n1 = n2
-            \* Prerequisites for taking a checkpoint must be satisfied
+            /\ (CanTakeCheckpoint[n1] /\ CanTakeCheckpoint[n2]) =>
+                /\ n1 = n2
+            /\ (IsTakingCheckpoint[n1] /\ IsTakingCheckpoint[n2]) =>
+                /\ n1 = n2
+                \* Prerequisites for taking a checkpoint must be satisfied
     /\ \A n \in Node:
-        /\ IsTakingCheckpoint[n] => CanTakeCheckpoint[n]
-        /\ CanTakeCheckpoint[n] => (CurrentLease[n] /= NoCheckpointLease)
-        /\ CanTakeCheckpoint[n] => CurrentLease[n].node = n
-        /\ CanTakeCheckpoint[n] => CurrentLease[n].counter >= TimeoutCounter
-        \* Replicated logs can never conflict
+            /\ IsTakingCheckpoint[n] => CanTakeCheckpoint[n]
+            /\ CanTakeCheckpoint[n] => (CurrentLease[n] /= NoCheckpointLease)
+            /\ CanTakeCheckpoint[n] => CurrentLease[n].node = n
+            /\ CanTakeCheckpoint[n] => CurrentLease[n].counter >= TimeoutCounter
+            \* Replicated logs can never conflict
     /\ \A i \in LogIndex:
-        /\ \A n1, n2 \in Node:
+            /\ \A n1, n2 \in Node:
                 \/ ReadLog(n1, i) = NoNode
                 \/ ReadLog(n2, i) = NoNode
                 \/ ReadLog(n1, i) = ReadLog(n2, i)
-            
+                
 (***************************************************************************)
 (* Expectations about system capabilities.                                 *)
 (***************************************************************************)
@@ -230,11 +230,11 @@ TemporalInvariant ==
             \/ CurrentLease[n].counter < TimeoutCounter
             \* If a node takes a checkpoint, eventually it will complete or timeout
     /\ \A n \in Node:
-        /\ IsTakingCheckpoint[n] ~>
-            \/ LastVotePayload[n] = ExecutionCounter[n]
-            \/ ~IsNodeUp[n]
-            \/ CurrentLease[n].counter < TimeoutCounter
-            \* Eventually, a checkpoint will be completed
+            /\ IsTakingCheckpoint[n] ~>
+                \/ LastVotePayload[n] = ExecutionCounter[n]
+                \/ ~IsNodeUp[n]
+                \/ CurrentLease[n].counter < TimeoutCounter
+                \* Eventually, a checkpoint will be completed
     /\ <>(LatestCheckpoint /= BlankLog)
 
 (***************************************************************************)

--- a/libtlafmt/tests/snapshots/format__corpus@DieHarder.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@DieHarder.tla.snap
@@ -73,9 +73,9 @@ JugToJug(j, k) ==
 (* disjunction.                                                            *)
 (***************************************************************************)
 Next == \E j \in Jug:
-        \/ FillJug(j)
-        \/ EmptyJug(j)
-        \/ \E k \in Jug \ {j}: JugToJug(j, k)
+    \/ FillJug(j)
+    \/ EmptyJug(j)
+    \/ \E k \in Jug \ {j}: JugToJug(j, k)
     
 (***************************************************************************)
 (* We define the formula Spec to be the complete specification, asserting  *)

--- a/libtlafmt/tests/snapshots/format__corpus@DiningPhilosophers.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@DiningPhilosophers.tla.snap
@@ -144,9 +144,9 @@ ProcSet == (1..NP)
 Init == (* Global variables *)
     /\ forks = [
         fork \in 1..NP |-> [
-        
+            
             holder |-> IF fork = 2 THEN 1 ELSE fork,
-        
+            
             clean |-> FALSE
         ]
     ]

--- a/libtlafmt/tests/snapshots/format__corpus@Disruptor_MPMC.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Disruptor_MPMC.tla.snap
@@ -110,9 +110,9 @@ AvailablePublishedSequence ==
         candidate_sequences == {guaranteed_published} \union Range(claimed_sequence)
     IN CHOOSE max \in candidate_sequences:
         IsPublished(max) => ~\E w \in Writers:
-                /\ claimed_sequence[w] = max + 1
-                /\ IsPublished(claimed_sequence[w])
-            
+            /\ claimed_sequence[w] = max + 1
+            /\ IsPublished(claimed_sequence[w])
+                
 (***************************************************************************)
 (* Producer Actions:                                                       *)
 (***************************************************************************)

--- a/libtlafmt/tests/snapshots/format__corpus@DistributedReplicatedLog.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@DistributedReplicatedLog.tla.snap
@@ -38,9 +38,9 @@ Copy(i) ==
 
 Extend(i) ==
     /\ \A j \in Servers:
-        Len(cLogs[j]) <= Len(cLogs[i])
+            Len(cLogs[j]) <= Len(cLogs[i])
     /\ \E s \in BoundedSeq(Values, Lag - Max({Len(cLogs[i]) - Len(cLogs[j]): j \in Servers})):
-        cLogs' = [cLogs EXCEPT ![i] = @ \o s]
+            cLogs' = [cLogs EXCEPT ![i] = @ \o s]
 
 Next ==
     \E i \in Servers:

--- a/libtlafmt/tests/snapshots/format__corpus@EWD998Chan_opts.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@EWD998Chan_opts.tla.snap
@@ -71,18 +71,18 @@ PassTokenOpts(n) ==
             /\ "pt2" \in F
             /\ \E j \in 1..Len(inbox[n]): inbox[n][j].type = "tok" /\ inbox[n][j].color = "black"
     /\ \E j \in 1..Len(inbox[n]):
-        /\ inbox[n][j].type = "tok"
-        \* the machine nr.i+1 transmits the token to machine nr.i under q := q + c[i+1]
-        /\ LET tkn == inbox[n][j]
-            IN inbox' = [inbox EXCEPT ![CASE "pt3" \in F /\ color[n] = "black" -> 0
-                            [] "pt4" \in F /\ tkn.color = "black" -> 0
-                            [] OTHER    ->  n-1 ] =
-                    Append(@, [tkn EXCEPT !.q = tkn.q + counter[n],
-                            !.color = IF color[n] = "black"
-                                THEN "black"
-                                ELSE tkn.color]),
-                ![n] = RemoveAt(@, j)] \* pass on the token.
-        (* Rule 7 *)
+            /\ inbox[n][j].type = "tok"
+            \* the machine nr.i+1 transmits the token to machine nr.i under q := q + c[i+1]
+            /\ LET tkn == inbox[n][j]
+                IN inbox' = [inbox EXCEPT ![CASE "pt3" \in F /\ color[n] = "black" -> 0
+                                [] "pt4" \in F /\ tkn.color = "black" -> 0
+                                [] OTHER    ->  n-1 ] =
+                        Append(@, [tkn EXCEPT !.q = tkn.q + counter[n],
+                                !.color = IF color[n] = "black"
+                                    THEN "black"
+                                    ELSE tkn.color]),
+                    ![n] = RemoveAt(@, j)] \* pass on the token.
+            (* Rule 7 *)
     /\ color' = [color EXCEPT ![n] = "white"]
     \* The state of the nodes remains unchanged by token-related actions.
     /\ UNCHANGED << active, counter >>

--- a/libtlafmt/tests/snapshots/format__corpus@EWD998_opts.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@EWD998_opts.tla.snap
@@ -79,8 +79,8 @@ PassTokenOpts(i) ==
             /\ "pt2" \in F
             /\ token.color = "black"
     /\ token' = [token EXCEPT !.pos = CASE "pt3" \in F /\ color[i] = "black" -> 0
-                [] "pt4" \in F /\ token.color = "black" -> 0
-                [] OTHER    ->  @ - 1 ,
+            [] "pt4" \in F /\ token.color = "black" -> 0
+            [] OTHER    ->  @ - 1 ,
         !.q = @ + counter[i],
         !.color = IF color[i] = "black" THEN "black" ELSE @]
     /\ color' = [color EXCEPT ![i] = "white"]

--- a/libtlafmt/tests/snapshots/format__corpus@Echo.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Echo.tla.snap
@@ -194,8 +194,8 @@ ParentIsNeighbor == \A n \in Node: parent[n] \in neighbors(n) \union {NoNode}
 (* A node n is a child of node m only if m is the parent of n.
    At the end of the computation, this is "if and only if". *)
 ParentChild == \A m, n \in Node:
-        /\ n \in children[m] => m = parent[n]
-        /\ m = parent[n] /\ pc[m] = "Done" => n \in children[m]
+    /\ n \in children[m] => m = parent[n]
+    /\ m = parent[n] /\ pc[m] = "Done" => n \in children[m]
     
 (* Compute the ancestor relation *)
 IsParent == [m, n \in Node |-> n = parent[m]]

--- a/libtlafmt/tests/snapshots/format__corpus@Elevator.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Elevator.tla.snap
@@ -69,16 +69,16 @@ SafetyInvariant == \* Some more comprehensive checks beyond the type invariant
                 /\ PersonState[p].location = e
                 /\ PersonState[p].destination = f
     /\ \A p \in Person: \* A person is in an elevator only if the elevator is moving toward their destination floor
-        /\ \A e \in Elevator:
-            /\ (PersonState[p].location = e /\ ElevatorState[e].floor /= PersonState[p].destination) =>
-                /\ ElevatorState[e].direction = GetDirection[ElevatorState[e].floor, PersonState[p].destination]
+            /\ \A e \in Elevator:
+                /\ (PersonState[p].location = e /\ ElevatorState[e].floor /= PersonState[p].destination) =>
+                    /\ ElevatorState[e].direction = GetDirection[ElevatorState[e].floor, PersonState[p].destination]
     /\ \A c \in ActiveElevatorCalls: PeopleWaiting[c.floor, c.direction] /= {} \* No ghost calls
 
 TemporalInvariant == \* Expectations about elevator system capabilities
     /\ \A c \in ElevatorCall: \* Every call is eventually serviced by an elevator
-        /\ c \in ActiveElevatorCalls ~> \E e \in Elevator: CanServiceCall[e, c]
+            /\ c \in ActiveElevatorCalls ~> \E e \in Elevator: CanServiceCall[e, c]
     /\ \A p \in Person: \* If a person waits for their elevator, they'll eventually arrive at their floor
-        /\ PersonState[p].waiting ~> PersonState[p].location = PersonState[p].destination
+            /\ PersonState[p].waiting ~> PersonState[p].location = PersonState[p].destination
 
 PickNewDestination(p) == \* Person decides they need to go to a different floor
     LET pState == PersonState[p] IN

--- a/libtlafmt/tests/snapshots/format__corpus@FastPaxos.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@FastPaxos.tla.snap
@@ -48,9 +48,9 @@ IsMajorityValue(M, v) == Cardinality(M) \div 2 < Cardinality({m \in M: m.value =
 FastAny ==
     /\ UNCHANGED << decision, maxBallot, maxVBallot, maxValue, cValue >>
     /\ \E f \in FastBallots:
-            /\ SendMessage([type |-> "P2a",
-                ballot |-> f,
-                value |-> any])
+        /\ SendMessage([type |-> "P2a",
+            ballot |-> f,
+            value |-> any])
         
 (*
     Phase 2b (Fast):
@@ -60,17 +60,17 @@ FastAny ==
 FastPropose ==
     /\ UNCHANGED << decision, cValue >>
     /\ \E a \in Replicas, m \in p2aMessages, v \in Values:
-            /\ m.value = any
-            /\ maxBallot[a] <= m.ballot
-            /\ maxValue[a] = none \/ maxValue[a] = v
-            /\ maxBallot' = [maxBallot EXCEPT ![a] = m.ballot]
-            /\ maxVBallot' = [maxVBallot EXCEPT ![a] = m.ballot]
-            /\ maxValue' = [maxValue EXCEPT ![a] = v]
-            /\ \A n \in p2bMessages: ~(n.ballot = m.ballot /\ n.acceptor = a)
-            /\ SendMessage([type |-> "P2b",
-                ballot |-> m.ballot,
-                acceptor |-> a,
-                value |-> v])
+        /\ m.value = any
+        /\ maxBallot[a] <= m.ballot
+        /\ maxValue[a] = none \/ maxValue[a] = v
+        /\ maxBallot' = [maxBallot EXCEPT ![a] = m.ballot]
+        /\ maxVBallot' = [maxVBallot EXCEPT ![a] = m.ballot]
+        /\ maxValue' = [maxValue EXCEPT ![a] = v]
+        /\ \A n \in p2bMessages: ~(n.ballot = m.ballot /\ n.acceptor = a)
+        /\ SendMessage([type |-> "P2b",
+            ballot |-> m.ballot,
+            acceptor |-> a,
+            value |-> v])
         
 (*
     A value is chosen if a fast quorum of acceptors proposed that value in a fast round.
@@ -88,7 +88,7 @@ FastDecide ==
             /\ \A a \in q: \E m \in M: m.acceptor = a
             /\ 1 = Cardinality(V)
             /\ \E m \in M: decision' = m.value
-        
+            
 (*
     Phase 2a (Classic)
 
@@ -109,15 +109,15 @@ ClassicAccept ==
         /\ LET M == {m \in p2bMessages: m.ballot = f /\ m.acceptor \in q}
                 V == {w \in Values: \E m \in M: w = m.value}
             IN
-                /\ \A a \in q: \E m \in M: m.acceptor = a
-                /\ 1 < Cardinality(V) \* Collision occurred.
-                /\ IF \E w \in V: IsMajorityValue(M, w)
-                THEN IsMajorityValue(M, v) \* Choose majority in quorum.
-                ELSE v \in V \* Choose any.
-                /\ SendMessage([type |-> "P2a",
-                    ballot |-> b,
-                    value |-> v])
-            
+            /\ \A a \in q: \E m \in M: m.acceptor = a
+            /\ 1 < Cardinality(V) \* Collision occurred.
+            /\ IF \E w \in V: IsMajorityValue(M, w)
+            THEN IsMajorityValue(M, v) \* Choose majority in quorum.
+            ELSE v \in V \* Choose any.
+            /\ SendMessage([type |-> "P2a",
+                ballot |-> b,
+                value |-> v])
+                
 (*
     Phase 2b (Classic)
 

--- a/libtlafmt/tests/snapshots/format__corpus@Hanoi.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Hanoi.tla.snap
@@ -45,8 +45,8 @@ Inv == Sum(towers) = 2 ^ D - 1
 (* Towers are naturals in the interval (0, 2^D] *)
 TypeOK ==
     /\ \A i \in DOMAIN towers:
-            /\ towers[i] \in Nat \* Towers are represented by natural numbers
-            /\ towers[i] < 2 ^ D
+        /\ towers[i] \in Nat \* Towers are represented by natural numbers
+        /\ towers[i] < 2 ^ D
         
 (***************************************************************************)
 (* Now we define of the initial predicate, that specifies the initial      *)
@@ -100,9 +100,9 @@ Move(from, to, disk) ==
 (* Define all possible actions that disks can perform.                     *)
 (***************************************************************************)
 Next == \E d \in SetOfPowerOfTwo(D): \E idx1, idx2 \in DOMAIN towers:
-        /\ idx1 /= idx2 \* No need to try to move onto the same tower (Move(...) prevents it too)
-        /\ Move(idx1, idx2, d)
-    
+    /\ idx1 /= idx2 \* No need to try to move onto the same tower (Move(...) prevents it too)
+    /\ Move(idx1, idx2, d)
+        
 (***************************************************************************)
 (* We define the formula Spec to be the complete specification, asserting  *)
 (* of a behavior that it begins in a state satisfying Init, and that every *)

--- a/libtlafmt/tests/snapshots/format__corpus@LamportMutex.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@LamportMutex.tla.snap
@@ -106,12 +106,12 @@ ReceiveRequest(p, q) ==
     /\ LET m == Head(network[q][p])
             c == m.clock
         IN
-            /\ m.type = "req"
-            /\ req' = [req EXCEPT ![p][q] = c]
-            /\ clock' = [clock EXCEPT ![p] = IF c > clock[p] THEN c + 1 ELSE @ + 1]
-            /\ network' = [network EXCEPT ![q][p] = Tail(@),
-                ![p][q] = Append(@, AckMessage)]
-            /\ UNCHANGED << ack, crit >>
+        /\ m.type = "req"
+        /\ req' = [req EXCEPT ![p][q] = c]
+        /\ clock' = [clock EXCEPT ![p] = IF c > clock[p] THEN c + 1 ELSE @ + 1]
+        /\ network' = [network EXCEPT ![q][p] = Tail(@),
+            ![p][q] = Append(@, AckMessage)]
+        /\ UNCHANGED << ack, crit >>
         
 (***************************************************************************)
 (* Process p receives an acknowledgement from q.                           *)

--- a/libtlafmt/tests/snapshots/format__corpus@LevelSpec.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@LevelSpec.tla.snap
@@ -831,18 +831,18 @@ TypeOK ==
                     /\ \A j \in 1..n.numberOfArgs:
                         Len(n.opLevelCond[i][j]) =
                         Node[n.params[i]].numberOfArgs
-        
+            
             /\ (n \in OpDeclNode) =>
                 /\ (n.kind = "ConstantDeclNode") => (n.level = 0)
                 /\ (n.kind = "VariableDeclNode") =>
                     /\ n.level = 1
                     /\ n.numberOfArgs = 0
-        
+            
             /\ (n \in OpApplNode) =>
             (Len(n.args) = Node[n.operator].numberOfArgs)
-        
+            
             /\ (n \in SubstitutionNode) => (Len(n.subFor) = Len(n.subWith))
-        
+            
             /\ (n \in InstanceNode) =>
                 /\ n.numberOfArgs = Len(n.params)
                 /\ (********************************************************)
@@ -897,17 +897,17 @@ SubstituteInLevelConstraint(rcd, subst) ==
          (* The set of substitution parameter numbers.                      *)
          (*******************************************************************)
 
-    ParamSubst(id) ==
-    (*******************************************************************)
+        ParamSubst(id) ==
+        (*******************************************************************)
          (* The set of "substitute parameters" of the parameter whose       *)
          (* NodeId is id.  If id is one of the parameters being substituted *)
          (* for in subst, then this is the set of LevelParams of the        *)
          (* expression being substituted for it; otherwise, it equals {id}. *)
          (*******************************************************************)
-        IF \E i \in paramNums: subst.subFor[i] = id
-        THEN LET subExpNum == CHOOSE i \in paramNums: subst.subFor[i] = id
-            IN Node[subst.subWith[subExpNum]].levelParams
-        ELSE {id}
+            IF \E i \in paramNums: subst.subFor[i] = id
+            THEN LET subExpNum == CHOOSE i \in paramNums: subst.subFor[i] = id
+                IN Node[subst.subWith[subExpNum]].levelParams
+            ELSE {id}
 
         IsOpParam(i) == Node[subst.subFor[i]].numberOfArgs > 0
     (*******************************************************************)
@@ -919,18 +919,18 @@ SubstituteInLevelConstraint(rcd, subst) ==
          (* The set of parameter numbers.                                   *)
          (*******************************************************************)
 
-    SubOp(opid) ==
-    (*******************************************************************)
+        SubOp(opid) ==
+        (*******************************************************************)
          (* If opid is the NodeId of an operator parameter, then this       *)
          (* equals the NodeId of the operator with which this operator is   *)
          (* substituted for by subst, which is opid itself if subst does    *)
          (* not substitute for opid.                                        *)
          (*******************************************************************)
-        IF \E i \in paramNums: subst.subFor[i] = opid
-        THEN LET subExpNum ==
-                CHOOSE i \in paramNums: subst.subFor[i] = opid
-            IN Node[subst.subWith[subExpNum]].ref
-        ELSE opid
+            IF \E i \in paramNums: subst.subFor[i] = opid
+            THEN LET subExpNum ==
+                    CHOOSE i \in paramNums: subst.subFor[i] = opid
+                IN Node[subst.subWith[subExpNum]].ref
+            ELSE opid
 
     IN [levelParams |->
             UNION {ParamSubst(id): id \in rcd.levelParams},
@@ -975,15 +975,15 @@ SubstituteInLevelConstraint(rcd, subst) ==
                 (* The set of all SubInALP(alp) with alp in ALP(i).         *)
                 (************************************************************)
             
-                LC(i, alp) ==
-                (************************************************************)
+                    LC(i, alp) ==
+                    (************************************************************)
                 (* The level constraint implied by an element alp of        *)
                 (* SubALP(i), if parameter i is an operator parameter       *)
                 (* instantiated by a defined operator.                      *)
                 (************************************************************)
-                    [param |-> alp.param,
-                        level |->
-                        Node[Node[subst.subWith[i]].ref].maxLevels[alp.idx]]
+                        [param |-> alp.param,
+                            level |->
+                            Node[Node[subst.subWith[i]].ref].maxLevels[alp.idx]]
             
                     OpDefParams ==
                     {i \in paramNums:
@@ -1127,7 +1127,7 @@ ModuleNodeLevelCorrect(n) ==
          (* OpDef nodes.                                                    *)
          (*******************************************************************)
 
-    allDefs == n.opDefs \union nonDefs
+        allDefs == n.opDefs \union nonDefs
 
     IN
         /\ (******************************************************************)
@@ -1794,16 +1794,16 @@ DefinedOpApplNodeLevelCorrect(n) ==
             (*      of level arg[j].level.                                  *)
             (****************************************************************)
                 (LET ALC(i, j) ==
-                        (*********************************************************)
+                    (*********************************************************)
                    (* If arg[i] is a declared operator, then this is the    *)
                    (* set of arg-level constraints implied for that         *)
                    (* operator by arg[j].level.                             *)
                    (*********************************************************)
-                            {[param |-> arg[i].ref,
-                                idx |-> k,
-                                level |-> arg[j].level]: k \in OpLevelCondIdx(i, j)}
+                        {[param |-> arg[i].ref,
+                            idx |-> k,
+                            level |-> arg[j].level]: k \in OpLevelCondIdx(i, j)}
                     
-                        IN UNION {ALC(i, j): i \in declOpArgs, j \in 1..p})
+                    IN UNION {ALC(i, j): i \in declOpArgs, j \in 1..p})
                 \union
                 (****************************************************************)
             (* 5. op.argLevelParams                                         *)

--- a/libtlafmt/tests/snapshots/format__corpus@MissionariesAndCannibals.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@MissionariesAndCannibals.tla.snap
@@ -175,12 +175,12 @@ Move(S, b) ==
     /\ LET newThisBank == who_is_on_bank[b] \ S
             newOtherBank == who_is_on_bank[OtherBank(b)] \union S
         IN
-            /\ IsSafe(newThisBank)
-            /\ IsSafe(newOtherBank)
-            /\ bank_of_boat' = OtherBank(b)
-            /\ who_is_on_bank' =
-                [i \in {"E", "W"} |-> IF i = b THEN newThisBank
-                    ELSE newOtherBank]
+        /\ IsSafe(newThisBank)
+        /\ IsSafe(newOtherBank)
+        /\ bank_of_boat' = OtherBank(b)
+        /\ who_is_on_bank' =
+            [i \in {"E", "W"} |-> IF i = b THEN newThisBank
+                ELSE newOtherBank]
         
 (***************************************************************************)
 (* The next-state formula Next describes all steps s -> t that represent a *)

--- a/libtlafmt/tests/snapshots/format__corpus@MultiPaxos.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@MultiPaxos.tla.snap
@@ -486,21 +486,21 @@ rloop(self) ==
                                 THEN "Preparing"
                                 ELSE @]]]
                     /\ msgs' = (msgs \union ({PrepareMsg(self, b),
-                        PrepareReplyMsg(self, b, VotesByNode(node' [self]))}))
+                                PrepareReplyMsg(self, b, VotesByNode(node' [self]))}))
                 /\ UNCHANGED << pending, observed >>
             \/
                 /\ \E m \in msgs:
-                    /\
-                        /\ m.type = "Prepare"
-                        /\ m.bal > node[self].balMaxKnown
-                    /\ node' = [node EXCEPT ![self].leader = m.src,
-                        ![self].balMaxKnown = m.bal,
-                        ![self].insts = [s \in Slots |->
-                            [node[self].insts[s]
-                            EXCEPT !.status = IF @ = "Accepting"
-                                THEN "Preparing"
-                                ELSE @]]]
-                    /\ msgs' = (msgs \union ({PrepareReplyMsg(self, m.bal, VotesByNode(node' [self]))}))
+                        /\
+                            /\ m.type = "Prepare"
+                            /\ m.bal > node[self].balMaxKnown
+                        /\ node' = [node EXCEPT ![self].leader = m.src,
+                            ![self].balMaxKnown = m.bal,
+                            ![self].insts = [s \in Slots |->
+                                [node[self].insts[s]
+                                EXCEPT !.status = IF @ = "Accepting"
+                                    THEN "Preparing"
+                                    ELSE @]]]
+                        /\ msgs' = (msgs \union ({PrepareReplyMsg(self, m.bal, VotesByNode(node' [self]))}))
                 /\ UNCHANGED << pending, observed >>
             \/
                 /\
@@ -522,7 +522,7 @@ rloop(self) ==
                                     ELSE @,
                                 !.cmd = PeakVotedCmd(prs, s)]]]
                     /\ msgs' = (msgs \union ({AcceptMsg(self, node' [self].balPrepared, s, node' [self].insts[s].cmd):
-                        s \in {s \in Slots: node' [self].insts[s].status = "Accepting"}}))
+                                s \in {s \in Slots: node' [self].insts[s].status = "Accepting"}}))
                 /\ UNCHANGED << pending, observed >>
             \/
                 /\

--- a/libtlafmt/tests/snapshots/format__corpus@Nano.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Nano.tla.snap
@@ -205,16 +205,16 @@ SumBag(B) ==
 
 BalanceInvariant ==
     /\ \A node \in Node:
-        LET
-            ledger == distributedLedger[node]
-            openAccounts == {account \in PublicKey: IsAccountOpen(ledger, account)}
-            topBlocks == {TopBlock(ledger, account): account \in openAccounts}
-            accountBalances ==
-                LET ledgerBalanceAt(hash) == BalanceAt(ledger, hash) IN
-                    BagOfAll(ledgerBalanceAt, SetToBag(topBlocks))
-        IN
-            /\ GenesisBlockExists =>
-                /\ SumBag(accountBalances) <= GenesisBalance
+            LET
+                ledger == distributedLedger[node]
+                openAccounts == {account \in PublicKey: IsAccountOpen(ledger, account)}
+                topBlocks == {TopBlock(ledger, account): account \in openAccounts}
+                accountBalances ==
+                    LET ledgerBalanceAt(hash) == BalanceAt(ledger, hash) IN
+                        BagOfAll(ledgerBalanceAt, SetToBag(topBlocks))
+            IN
+                /\ GenesisBlockExists =>
+                    /\ SumBag(accountBalances) <= GenesisBalance
 
 SafetyInvariant ==
     /\ CryptographicInvariant

--- a/libtlafmt/tests/snapshots/format__corpus@ParReach.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@ParReach.tla.snap
@@ -193,8 +193,8 @@ Inv ==
     /\ toVroot \in [Procs -> SUBSET Nodes]
     /\ pc \in [Procs -> {"a", "b", "c", "Done"}]
     /\ \A q \in Procs:
-            /\ (pc[q] \in {"a", "b", "Done"}) => (toVroot[q] = {})
-            /\ (pc[q] = "b") => (u[q] \in vroot \union marked)
+        /\ (pc[q] \in {"a", "b", "Done"}) => (toVroot[q] = {})
+        /\ (pc[q] = "b") => (u[q] \in vroot \union marked)
         
 (***************************************************************************)
 (* To define a refinement mapping from states of the parallel algorithm to *)

--- a/libtlafmt/tests/snapshots/format__corpus@Paxos.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Paxos.tla.snap
@@ -97,13 +97,13 @@ PaxosPrepare ==
 PaxosPromise ==
     /\ UNCHANGED << decision, maxVBallot, maxValue >>
     /\ \E a \in Replicas, m \in p1aMessages:
-            /\ maxBallot[a] < m.ballot
-            /\ maxBallot' = [maxBallot EXCEPT ![a] = m.ballot]
-            /\ SendMessage([type |-> "P1b",
-                ballot |-> m.ballot,
-                acceptor |-> a,
-                maxVBallot |-> maxVBallot[a],
-                maxValue |-> maxValue[a]])
+        /\ maxBallot[a] < m.ballot
+        /\ maxBallot' = [maxBallot EXCEPT ![a] = m.ballot]
+        /\ SendMessage([type |-> "P1b",
+            ballot |-> m.ballot,
+            acceptor |-> a,
+            maxVBallot |-> maxVBallot[a],
+            maxValue |-> maxValue[a]])
         
 (*
     Phase 2a:
@@ -133,7 +133,7 @@ PaxosAccept ==
                 /\ SendMessage([type |-> "P2a",
                     ballot |-> b,
                     value |-> v])
-            
+                
 (*
     Phase 2b:
 
@@ -149,15 +149,15 @@ PaxosAccept ==
 PaxosAccepted ==
     /\ UNCHANGED << decision >>
     /\ \E a \in Replicas, m \in p2aMessages:
-            /\ m.value \in Values
-            /\ maxBallot[a] <= m.ballot
-            /\ maxBallot' = [maxBallot EXCEPT ![a] = m.ballot]
-            /\ maxVBallot' = [maxVBallot EXCEPT ![a] = m.ballot]
-            /\ maxValue' = [maxValue EXCEPT ![a] = m.value]
-            /\ SendMessage([type |-> "P2b",
-                ballot |-> m.ballot,
-                acceptor |-> a,
-                value |-> m.value])
+        /\ m.value \in Values
+        /\ maxBallot[a] <= m.ballot
+        /\ maxBallot' = [maxBallot EXCEPT ![a] = m.ballot]
+        /\ maxVBallot' = [maxVBallot EXCEPT ![a] = m.ballot]
+        /\ maxValue' = [maxValue EXCEPT ![a] = m.value]
+        /\ SendMessage([type |-> "P2b",
+            ballot |-> m.ballot,
+            acceptor |-> a,
+            value |-> m.value])
         
 (*
     Consensus is achieved when a majority of acceptors accept the same ballot number (rather than the same value).
@@ -208,8 +208,8 @@ PaxosNontriviality ==
         \/ decision = none
         \/ \E m \in p2aMessages: m.value = decision
     /\ \A m \in p1bMessages:
-            /\ m.maxValue \in Values \/ 0 = m.maxVBallot
-            /\ m.maxValue = none \/ 0 < m.maxVBallot
+        /\ m.maxValue \in Values \/ 0 = m.maxVBallot
+        /\ m.maxValue = none \/ 0 < m.maxVBallot
         
 \* Consistency safety property: At most 1 value can be learnt.
 PaxosConsistency == [][decision = none]_<< decision >>

--- a/libtlafmt/tests/snapshots/format__corpus@ProtoReals.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@ProtoReals.tla.snap
@@ -36,11 +36,11 @@ IsModelOfReals(R, Plus, Times, Leq) ==
                 /\ (a + c) <= (b + c)
                 /\ (Zero <= c) => (a * c) <= (b * c)
         /\ \A S \in SUBSET R:
-            LET SBound(a) == \A s \in S: s <= a
-            IN (\E a \in R: SBound(a)) =>
-                (\E sup \in R:
-                    /\ SBound(sup)
-                    /\ \A a \in R: SBound(a) => (sup <= a))
+                LET SBound(a) == \A s \in S: s <= a
+                IN (\E a \in R: SBound(a)) =>
+                    (\E sup \in R:
+                        /\ SBound(sup)
+                        /\ \A a \in R: SBound(a) => (sup <= a))
 
 THEOREM \E R, Plus, Times, Leq : IsModelOfReals(R, Plus, Times, Leq)
 --------------------------------------------------------------------------------
@@ -77,8 +77,8 @@ a ^ b ==
                 /\ \A m, n \in Int: (r /= Zero) =>
                     (f[r, m + n] = f[r, m] * f[r, n])
             /\ \A r \in RPos:
-                /\ f[Zero, r] = Zero
-                /\ \A s, t \in Real: f[r, s * t] = f[f[r, s], t]
-                /\ \A s, t \in RPos: (s <= t) => (f[r, s] <= f[r, t])
+                    /\ f[Zero, r] = Zero
+                    /\ \A s, t \in Real: f[r, s * t] = f[f[r, s], t]
+                    /\ \A s, t \in RPos: (s <= t) => (f[r, s] <= f[r, t])
     IN exp[a, b]
 ================================================================================

--- a/libtlafmt/tests/snapshots/format__corpus@SPA_Attack.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@SPA_Attack.tla.snap
@@ -688,16 +688,16 @@ FwProcEndPointAccess ==
 \* A 3 Tuple ACL Rule configured by SDP controller automatically deleted due to aging mechanism.
 \* Variables changed: <AclRuleSet,AgedRuleSet >  
 FwProcAclTimeOut == \E r \in AclRuleSet: \*aging and deleted randomly,remove from current rule table
-        /\ r.sPort = MATCH_ANY \*only 3 tuple rule with aging mechanism
-        /\ FwState = "Work"
-        /\ AclRuleSet' = AclRuleSet \ {r}
-        /\ AgedRuleSet' = AgedRuleSet \union {r} \* record aged rule into log.
-        /\ UNCHANGED user_vars
-        /\ UNCHANGED sdpsvr_vars
-        /\ UNCHANGED attacker_vars
-        /\ UNCHANGED << FwState, DropPackets >>
-        /\ UNCHANGED server_vars
-        /\ UNCHANGED Public_vars
+    /\ r.sPort = MATCH_ANY \*only 3 tuple rule with aging mechanism
+    /\ FwState = "Work"
+    /\ AclRuleSet' = AclRuleSet \ {r}
+    /\ AgedRuleSet' = AgedRuleSet \union {r} \* record aged rule into log.
+    /\ UNCHANGED user_vars
+    /\ UNCHANGED sdpsvr_vars
+    /\ UNCHANGED attacker_vars
+    /\ UNCHANGED << FwState, DropPackets >>
+    /\ UNCHANGED server_vars
+    /\ UNCHANGED Public_vars
     
 (***************************************************************************)
 (* `^                                                                      *)
@@ -1318,17 +1318,17 @@ WithOutDropPkts(x) == ~WithDropPkts(x)
 
 FwCorrectProperty == \*to simplify the model, we don't consider TCP packets re-transport mechanism, so established TCP links without packet dropping.
 <>[](
-        /\ \A x \in aTCPLinkSet: IF x.State = "ESTABLISHED"
-            THEN
-                WithOutDropPkts(x)
-            ELSE
-                WithDropPkts(x)
+    /\ \A x \in aTCPLinkSet: IF x.State = "ESTABLISHED"
+        THEN
+            WithOutDropPkts(x)
+        ELSE
+            WithDropPkts(x)
     
-        /\ \A x \in uTCPLinkSet: IF x.State = "ESTABLISHED"
-            THEN
-                WithOutDropPkts(x)
-            ELSE
-                WithDropPkts(x)
+    /\ \A x \in uTCPLinkSet: IF x.State = "ESTABLISHED"
+        THEN
+            WithOutDropPkts(x)
+        ELSE
+            WithDropPkts(x)
 )
 ================================================================================
 \* Modification History

--- a/libtlafmt/tests/snapshots/format__corpus@TransitiveClosure.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@TransitiveClosure.tla.snap
@@ -76,7 +76,7 @@ TC1(R) ==
 R ** T == LET SR == Support(R)
         ST == Support(T)
     IN { <<r, t>> \in SR \X ST:
-    \E s \in SR \intersect ST: (<< r, s >> \in R) /\ (<< s, t >> \in T)}
+        \E s \in SR \intersect ST: (<< r, s >> \in R) /\ (<< s, t >> \in T)}
 
 (***************************************************************************)
 (* We can then define the closure of R to equal                            *)

--- a/libtlafmt/tests/snapshots/format__corpus@Voting.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Voting.tla.snap
@@ -172,8 +172,8 @@ Inv == TypeOK /\ VotesSafe /\ OneValuePerBallot
 ShowsSafeAt(Q, b, v) ==
     /\ \A a \in Q: maxBal[a] >= b
     /\ \E c \in - 1..(b - 1):
-            /\ (c /= - 1) => \E a \in Q: VotedFor(a, c, v)
-            /\ \A d \in (c + 1)..(b - 1), a \in Q: DidNotVoteAt(a, d)
+        /\ (c /= - 1) => \E a \in Q: VotedFor(a, c, v)
+        /\ \A d \in (c + 1)..(b - 1), a \in Q: DidNotVoteAt(a, d)
         
 (***************************************************************************)
 (* This is the theorem that's at the heart of the algorithm.  It shows     *)

--- a/libtlafmt/tests/snapshots/format__corpus@aba_asyn_byz.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@aba_asyn_byz.tla.snap
@@ -127,12 +127,12 @@ Decide(i) ==
 
 Next ==
     /\ \E self \in Proc:
-            \/ BecomeByzantine(self)
-            \/ Receive(self, TRUE)
-            \/ SendEcho(self)
-            \/ SendReady(self)
-            \/ Decide(self)
-            \/ UNCHANGED vars
+        \/ BecomeByzantine(self)
+        \/ Receive(self, TRUE)
+        \/ SendEcho(self)
+        \/ SendReady(self)
+        \/ Decide(self)
+        \/ UNCHANGED vars
         
 (* Add weak fairness condition since we want to check liveness properties.  *)
 Spec == Init /\ [][Next]_vars

--- a/libtlafmt/tests/snapshots/format__corpus@bcastFolklore.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@bcastFolklore.tla.snap
@@ -63,9 +63,9 @@ InitNoBcast ==
 Receive(self) == (* a correct process self receives new messages *)
     /\ pc[self] /= "CR"
     /\ \E msgs \in SUBSET (Proc \times M): (* msgs is a set of messages which has been received  *)
-            /\ msgs \subseteq sent
-            /\ rcvd[self] \subseteq msgs
-            /\ rcvd' = [rcvd EXCEPT ![self] = msgs]
+        /\ msgs \subseteq sent
+        /\ rcvd[self] \subseteq msgs
+        /\ rcvd' = [rcvd EXCEPT ![self] = msgs]
         
 (* If a correct process received an INIT message or was initialized with V1, 
    it accepts this message and then broadcasts ECHO to all.  

--- a/libtlafmt/tests/snapshots/format__corpus@c1cs.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@c1cs.tla.snap
@@ -61,10 +61,10 @@ Crash(i) ==
 Receive(i) ==
     /\ pc[i] /= "CRASH"
     /\ \E sndr \in Proc, msg \in Msg:
-            /\ msg \in bcastMsg
-            /\ msg \notin rcvdMsg[i]
-            /\ rcvdMsg' = [rcvdMsg EXCEPT ![i] = rcvdMsg[i] \union {msg}]
-            /\ UNCHANGED << pc, v, dValue, bcastMsg >>
+        /\ msg \in bcastMsg
+        /\ msg \notin rcvdMsg[i]
+        /\ rcvdMsg' = [rcvdMsg EXCEPT ![i] = rcvdMsg[i] \union {msg}]
+        /\ UNCHANGED << pc, v, dValue, bcastMsg >>
         
 (* Broadcasts PROPOSED(v_i) *)
 Propose(i) ==
@@ -100,11 +100,11 @@ T2(i) ==
     /\ pc[i] /= "DONE"
     /\ pc[i] /= "CRASH"
     /\ \E msg \in rcvdMsg[i]:
-            /\ msg.type = "Decision"
-            /\ dValue' = [dValue EXCEPT ![i] = msg.value]
-            /\ bcastMsg' = bcastMsg \union {makeDecisionMsg(dValue' [i], i)}
-            /\ pc' = [pc EXCEPT ![i] = "DONE"]
-            /\ UNCHANGED << v, rcvdMsg >>
+        /\ msg.type = "Decision"
+        /\ dValue' = [dValue EXCEPT ![i] = msg.value]
+        /\ bcastMsg' = bcastMsg \union {makeDecisionMsg(dValue' [i], i)}
+        /\ pc' = [pc EXCEPT ![i] = "DONE"]
+        /\ UNCHANGED << v, rcvdMsg >>
         
 (* Just to avoid deadlock checking. *)
 DoNothing(i) ==

--- a/libtlafmt/tests/snapshots/format__corpus@cf1s_folklore.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@cf1s_folklore.tla.snap
@@ -109,11 +109,11 @@ Decide(i) ==
 
 Next ==
     /\ \E self \in Proc:
-            \/ Receive(self)
-            \/ Propose(self)
-            \/ Decide(self)
-            \/ Faulty(self)
-            \/ UNCHANGED vars
+        \/ Receive(self)
+        \/ Propose(self)
+        \/ Decide(self)
+        \/ Faulty(self)
+        \/ UNCHANGED vars
         
 (* Add weak fairness condition since we want to check liveness properties.  *)
 (* We require that if UponV1 (UponNonFaulty, UponAcceptNotSent, UponAccept) *)

--- a/libtlafmt/tests/snapshots/format__corpus@nbacg_guer01.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@nbacg_guer01.tla.snap
@@ -142,14 +142,14 @@ Commit(i) ==
 
 Next ==
     /\ \E self \in Proc:
-            \/ Crash(self)
-            \/ Receive(self)
-            \/ SendYes(self)
-            \/ SendNo(self)
-            \/ AbortNoYes(self)
-            \/ AbortSent(self)
-            \/ Commit(self)
-            \/ UNCHANGED vars (* Avoid deadlocks. 
+        \/ Crash(self)
+        \/ Receive(self)
+        \/ SendYes(self)
+        \/ SendNo(self)
+        \/ AbortNoYes(self)
+        \/ AbortSent(self)
+        \/ Commit(self)
+        \/ UNCHANGED vars (* Avoid deadlocks. 
                                  After deciding, a correct process does nothing. *)
         
 (* 


### PR DESCRIPTION
This is a bit of a mixed bag - it improves indentation of some specs, but makes others worse - there's a followup PR for the latter specs.

This is algorithmically the indented behaviour though.

---

* fix: do not respect indent of newlines for rewrite (224ee56)
      
      Ignore the indentation attached to newline tokens when performing an
      indent rewrite pass.