### PR TITLE
fix: connective item body indentation

### DIFF
--- a/libtlafmt/src/ast_format/list_item.rs
+++ b/libtlafmt/src/ast_format/list_item.rs
@@ -1,0 +1,38 @@
+use tree_sitter::Node;
+
+use crate::{format_node, token::Token, EmptyLines, Error, Renderer};
+
+/// Render a conjunctive or disjunctive list item, indenting the body of the
+/// item by 1.
+pub(super) fn format_list_item<'a, W>(
+    def: Node<'a>,
+    input: &'a str,
+    empty_lines: &mut EmptyLines,
+    writer: &mut Renderer<'a, W>,
+) -> Result<(), Error>
+where
+    W: std::io::Write,
+{
+    empty_lines.maybe_insert(&def, writer)?;
+    writer.push(Token::Newline)?;
+
+    let mut c = def.walk();
+    let iter = def.named_children(&mut c).peekable();
+    for n in iter {
+        match n.kind() {
+            "bullet_conj" => {
+                writer.push(Token::And)?;
+                writer.indent_inc();
+            }
+            "bullet_disj" => {
+                writer.push(Token::Or)?;
+                writer.indent_inc();
+            }
+            _ => format_node(n, input, empty_lines, writer)?,
+        }
+    }
+
+    writer.indent_dec();
+
+    Ok(())
+}

--- a/libtlafmt/src/ast_format/mod.rs
+++ b/libtlafmt/src/ast_format/mod.rs
@@ -5,6 +5,7 @@
 
 mod case;
 mod comment;
+mod list_item;
 mod module;
 mod node;
 

--- a/libtlafmt/src/ast_format/node.rs
+++ b/libtlafmt/src/ast_format/node.rs
@@ -1,7 +1,7 @@
 use tree_sitter::Node;
 
 use crate::{
-    ast_format::{case::format_case, format_comment, format_module},
+    ast_format::{case::format_case, format_comment, format_module, list_item::format_list_item},
     get_str,
     helpers::EmptyLines,
     token::Token,
@@ -130,8 +130,7 @@ where
         // Conjunction and disjunction always appear on newlines and are never
         // explicitly indented - the parent list nodes are indented instead.
         "conj_item" | "disj_item" => {
-            writer.push(Token::Newline)?;
-            skip_indent = true
+            return format_list_item(def, input, empty_lines, writer);
         }
 
         // These are always indented.

--- a/libtlafmt/src/renderer/snapshots/libtlafmt__renderer__indent__tests__conj_list_in_bounded_quantification_then_comment.snap
+++ b/libtlafmt/src/renderer/snapshots/libtlafmt__renderer__indent__tests__conj_list_in_bounded_quantification_then_comment.snap
@@ -8,6 +8,6 @@ ClientRejectsBadMetadata ==
     /\ \A f \in target_files:
         /\ BadKey \notin f.sigs
         /\ f.version /= InvalidVersion
-        
+            
 \* This repro only happens when there's a comment here
 ================================================================================

--- a/libtlafmt/tests/snapshots/format__corpus@2PCwithBTM.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@2PCwithBTM.tla.snap
@@ -87,30 +87,30 @@ Init == (* Global variables *)
 RS(self) ==
     /\ pc[self] = "RS"
     /\ IF rmState[self] \in {"working", "prepared"}
-    THEN
-        /\
-            \/
-                /\ rmState[self] = "working"
-                /\ rmState' = [rmState EXCEPT ![self] = "prepared"]
-            \/
-                /\
-                    \/
-                        /\ tmState = "commit"
-                        /\ rmState' = [rmState EXCEPT ![self] = "committed"]
-                    \/
-                        /\ rmState[self] = "working" \/ tmState = "abort"
-                        /\ rmState' = [rmState EXCEPT ![self] = "aborted"]
-            \/
-                /\ IF RMMAYFAIL /\ ~\E rm \in RM: rmState[rm] = "failed"
-                THEN
-                    /\ rmState' = [rmState EXCEPT ![self] = "failed"]
-                ELSE
-                    /\ TRUE
-                    /\ UNCHANGED rmState
-        /\ pc' = [pc EXCEPT ![self] = "RS"]
-    ELSE
-        /\ pc' = [pc EXCEPT ![self] = "Done"]
-        /\ UNCHANGED rmState
+        THEN
+            /\
+                \/
+                    /\ rmState[self] = "working"
+                    /\ rmState' = [rmState EXCEPT ![self] = "prepared"]
+                \/
+                    /\
+                        \/
+                            /\ tmState = "commit"
+                            /\ rmState' = [rmState EXCEPT ![self] = "committed"]
+                        \/
+                            /\ rmState[self] = "working" \/ tmState = "abort"
+                            /\ rmState' = [rmState EXCEPT ![self] = "aborted"]
+                \/
+                        /\ IF RMMAYFAIL /\ ~\E rm \in RM: rmState[rm] = "failed"
+                            THEN
+                                /\ rmState' = [rmState EXCEPT ![self] = "failed"]
+                            ELSE
+                                /\ TRUE
+                                /\ UNCHANGED rmState
+            /\ pc' = [pc EXCEPT ![self] = "RS"]
+        ELSE
+            /\ pc' = [pc EXCEPT ![self] = "Done"]
+            /\ UNCHANGED rmState
     /\ UNCHANGED tmState
 
 RManager(self) == RS(self)
@@ -135,11 +135,11 @@ TC ==
 F1 ==
     /\ pc[0] = "F1"
     /\ IF TMMAYFAIL
-    THEN
-        /\ tmState' = "hidden"
-    ELSE
-        /\ TRUE
-        /\ UNCHANGED tmState
+        THEN
+            /\ tmState' = "hidden"
+        ELSE
+            /\ TRUE
+            /\ UNCHANGED tmState
     /\ pc' = [pc EXCEPT ![0] = "Done"]
     /\ UNCHANGED rmState
 
@@ -152,11 +152,11 @@ TA ==
 F2 ==
     /\ pc[0] = "F2"
     /\ IF TMMAYFAIL
-    THEN
-        /\ tmState' = "hidden"
-    ELSE
-        /\ TRUE
-        /\ UNCHANGED tmState
+        THEN
+            /\ tmState' = "hidden"
+        ELSE
+            /\ TRUE
+            /\ UNCHANGED tmState
     /\ pc' = [pc EXCEPT ![0] = "Done"]
     /\ UNCHANGED rmState
 

--- a/libtlafmt/tests/snapshots/format__corpus@ACP_NB.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@ACP_NB.tla.snap
@@ -69,10 +69,10 @@ forward(i, j) ==
     /\ participant[i].forward[i] /= notsent
     /\ participant[i].forward[j] = notsent
     /\ participant' = [participant EXCEPT ![i] =
-        [@ EXCEPT !.forward =
-            [@ EXCEPT ![j] = participant[i].forward[i]]
+                [@ EXCEPT !.forward =
+                    [@ EXCEPT ![j] = participant[i].forward[i]]
+                ]
         ]
-    ]
     /\ UNCHANGED << coordinator >>
 
 \* preDecideOnForward(i,j): participant i receives decision from participant j
@@ -89,10 +89,10 @@ preDecideOnForward(i, j) ==
     /\ participant[i].forward[i] = notsent
     /\ participant[j].forward[i] /= notsent
     /\ participant' = [participant EXCEPT ![i] =
-        [@ EXCEPT !.forward =
-            [@ EXCEPT ![i] = participant[j].forward[i]]
+                [@ EXCEPT !.forward =
+                    [@ EXCEPT ![i] = participant[j].forward[i]]
+                ]
         ]
-    ]
     /\ UNCHANGED << coordinator >>
 
 \* preDecide(i): participant i receives decision from coordinator
@@ -108,10 +108,10 @@ preDecide(i) ==
     /\ participant[i].forward[i] = notsent
     /\ coordinator.broadcast[i] /= notsent
     /\ participant' = [participant EXCEPT ![i] =
-        [@ EXCEPT !.forward =
-            [@ EXCEPT ![i] = coordinator.broadcast[i]]
+                [@ EXCEPT !.forward =
+                    [@ EXCEPT ![i] = coordinator.broadcast[i]]
+                ]
         ]
-    ]
     /\ UNCHANGED << coordinator >>
 
 \* decideNB(i): Actual decision, after predecision has been forwarded
@@ -125,8 +125,8 @@ decideNB(i) ==
     /\ participant[i].alive
     /\ \A j \in participants: participant[i].forward[j] /= notsent
     /\ participant' = [participant EXCEPT ![i] =
-        [@ EXCEPT !.decision = participant[i].forward[i]]
-    ]
+                [@ EXCEPT !.decision = participant[i].forward[i]]
+        ]
     /\ UNCHANGED << coordinator >>
 
 \* abortOnTimeout(i): conditions for a timeout are simulated

--- a/libtlafmt/tests/snapshots/format__corpus@ACP_NB_WRONG_TLC.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@ACP_NB_WRONG_TLC.tla.snap
@@ -65,10 +65,10 @@ forward(i, j) ==
     /\ participant[i].decision /= notsent
     /\ participant[i].forward[j] = notsent
     /\ participant' = [participant EXCEPT ![i] =
-        [@ EXCEPT !.forward =
-            [@ EXCEPT ![j] = participant[i].decision]
+                [@ EXCEPT !.forward =
+                    [@ EXCEPT ![j] = participant[i].decision]
+                ]
         ]
-    ]
     /\ UNCHANGED << coordinator >>
 
 \* decideOnForward(i,j): participant i receives decision from participant j
@@ -85,8 +85,8 @@ decideOnForward(i, j) ==
     /\ participant[i].decision = undecided
     /\ participant[j].forward[i] /= notsent
     /\ participant' = [participant EXCEPT ![i] =
-        [@ EXCEPT !.decision = participant[j].forward[i]]
-    ]
+                [@ EXCEPT !.decision = participant[j].forward[i]]
+        ]
     /\ UNCHANGED << coordinator >>
 
 \* abortOnTimeout(i): conditions for a timeout are simulated

--- a/libtlafmt/tests/snapshots/format__corpus@ACP_SB.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@ACP_SB.tla.snap
@@ -106,8 +106,8 @@ request(i) ==
     /\ coordinator.alive
     /\ ~coordinator.request[i]
     /\ coordinator' = [coordinator EXCEPT !.request =
-        [@ EXCEPT ![i] = TRUE]
-    ]
+                [@ EXCEPT ![i] = TRUE]
+        ]
     /\ UNCHANGED << participant >>
 
 \* getVote(i):
@@ -127,8 +127,8 @@ getVote(i) ==
     /\ coordinator.vote[i] = waiting
     /\ participant[i].voteSent
     /\ coordinator' = [coordinator EXCEPT !.vote =
-        [@ EXCEPT ![i] = participant[i].vote]
-    ]
+                [@ EXCEPT ![i] = participant[i].vote]
+        ]
     /\ UNCHANGED << participant >>
 
 \* detectFault(i):
@@ -190,8 +190,8 @@ coordBroadcast(i) ==
     /\ coordinator.decision /= undecided
     /\ coordinator.broadcast[i] = notsent
     /\ coordinator' = [coordinator EXCEPT !.broadcast =
-        [@ EXCEPT ![i] = coordinator.decision]
-    ]
+                [@ EXCEPT ![i] = coordinator.decision]
+        ]
     /\ UNCHANGED << participant >>
 
 \* coordDie:
@@ -221,8 +221,8 @@ sendVote(i) ==
     /\ participant[i].alive
     /\ coordinator.request[i]
     /\ participant' = [participant EXCEPT ![i] =
-        [@ EXCEPT !.voteSent = TRUE]
-    ]
+                [@ EXCEPT !.voteSent = TRUE]
+        ]
     /\ UNCHANGED << coordinator >>
 
 \* abortOnVote(i):
@@ -240,8 +240,8 @@ abortOnVote(i) ==
     /\ participant[i].voteSent
     /\ participant[i].vote = no
     /\ participant' = [participant EXCEPT ![i] =
-        [@ EXCEPT !.decision = abort]
-    ]
+                [@ EXCEPT !.decision = abort]
+        ]
     /\ UNCHANGED << coordinator >>
 
 \* abortOnTimeoutRequest(i):
@@ -258,8 +258,8 @@ abortOnTimeoutRequest(i) ==
     /\ ~coordinator.alive
     /\ ~coordinator.request[i]
     /\ participant' = [participant EXCEPT ![i] =
-        [@ EXCEPT !.decision = abort]
-    ]
+                [@ EXCEPT !.decision = abort]
+        ]
     /\ UNCHANGED << coordinator >>
 
 \* decide(i):
@@ -276,8 +276,8 @@ decide(i) ==
     /\ participant[i].decision = undecided
     /\ coordinator.broadcast[i] /= notsent
     /\ participant' = [participant EXCEPT ![i] =
-        [@ EXCEPT !.decision = coordinator.broadcast[i]]
-    ]
+                [@ EXCEPT !.decision = coordinator.broadcast[i]]
+        ]
     /\ UNCHANGED << coordinator >>
 
 \* parDie(i):
@@ -289,8 +289,8 @@ decide(i) ==
 parDie(i) ==
     /\ participant[i].alive
     /\ participant' = [participant EXCEPT ![i] =
-        [@ EXCEPT !.alive = FALSE, !.faulty = TRUE]
-    ]
+                [@ EXCEPT !.alive = FALSE, !.faulty = TRUE]
+        ]
     /\ UNCHANGED << coordinator >>
 
 --------------------------------------------------------------------------------

--- a/libtlafmt/tests/snapshots/format__corpus@BinarySearch.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@BinarySearch.tla.snap
@@ -65,26 +65,26 @@ Init == (* Global variables *)
 a ==
     /\ pc = "a"
     /\ IF low <= high /\ result = 0
-    THEN
-        /\ LET mid == (low + high) \div 2 IN
-            LET mval == seq[mid] IN
-                IF mval = val
-                THEN
-                    /\ result' = mid
-                    /\ UNCHANGED << low, high >>
-                ELSE
-                    /\ IF val < mval
+        THEN
+            /\ LET mid == (low + high) \div 2 IN
+                LET mval == seq[mid] IN
+                    IF mval = val
                     THEN
-                        /\ high' = mid - 1
-                        /\ low' = low
+                        /\ result' = mid
+                        /\ UNCHANGED << low, high >>
                     ELSE
-                        /\ low' = mid + 1
-                        /\ high' = high
-                    /\ UNCHANGED result
-        /\ pc' = "a"
-    ELSE
-        /\ pc' = "Done"
-        /\ UNCHANGED << low, high, result >>
+                        /\ IF val < mval
+                            THEN
+                                /\ high' = mid - 1
+                                /\ low' = low
+                            ELSE
+                                /\ low' = mid + 1
+                                /\ high' = high
+                        /\ UNCHANGED result
+            /\ pc' = "a"
+        ELSE
+            /\ pc' = "Done"
+            /\ UNCHANGED << low, high, result >>
     /\ UNCHANGED << seq, val >>
 
 (* Allow infinite stuttering to prevent deadlock on termination. *)

--- a/libtlafmt/tests/snapshots/format__corpus@BufferedRandomAccessFile.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@BufferedRandomAccessFile.tla.snap
@@ -117,12 +117,12 @@ FlushBuffer ==
     /\ dirty
     /\ LET len == Min(length - lo, BuffSz) IN
         /\ IF len > 0
-        THEN LET diskPosA == lo IN \* super.seek(this.lo)
-            /\ file_content' = WriteToFile(file_content, diskPosA, ArraySlice(buff, 0, len))
-            /\ file_pointer' = diskPosA + len
-            /\ diskPos' = lo + len
-        ELSE
-        UNCHANGED << diskPos, file_pointer, file_content >>
+            THEN LET diskPosA == lo IN \* super.seek(this.lo)
+                /\ file_content' = WriteToFile(file_content, diskPosA, ArraySlice(buff, 0, len))
+                /\ file_pointer' = diskPosA + len
+                /\ diskPos' = lo + len
+            ELSE
+            UNCHANGED << diskPos, file_pointer, file_content >>
         /\ dirty' = FALSE
     /\ UNCHANGED << length, curr, lo, buff >>
 
@@ -142,23 +142,23 @@ FillBuffer ==
 Seek(pos) ==
     /\ curr' = pos
     /\ IF pos < lo \/ pos >= (lo + BuffSz) THEN
-        /\ ~dirty \* call to FlushBuffer
-        /\ lo' = (pos \div BuffSz) * BuffSz
-        /\ FillBuffer
-    ELSE
-    UNCHANGED << lo, diskPos, file_pointer, buff >>
+            /\ ~dirty \* call to FlushBuffer
+            /\ lo' = (pos \div BuffSz) * BuffSz
+            /\ FillBuffer
+        ELSE
+        UNCHANGED << lo, diskPos, file_pointer, buff >>
     /\ UNCHANGED << dirty, length, file_content >>
 
 SetLength(newLength) ==
     /\ file_content' = TruncateOrExtendFile(file_content, newLength)
     /\ IF ArrayLen(file_content) > newLength /\ file_pointer > newLength
-    THEN file_pointer' = newLength
-    ELSE file_pointer' \in Offset
+        THEN file_pointer' = newLength
+        ELSE file_pointer' \in Offset
     /\ length' = newLength
     /\ diskPos' = file_pointer'
     /\ IF curr > newLength
-    THEN curr' = newLength
-    ELSE UNCHANGED curr
+        THEN curr' = newLength
+        ELSE UNCHANGED curr
     \* In reality the buffer doesn't change---but some of its bytes might no
     \* longer be relevant and have to be marked as arbitrary.
     /\ buff' = MkArray(BuffSz, [i \in 0..(BuffSz - 1) |->
@@ -356,8 +356,8 @@ SetLength(new_length) ==
     \*
     \* [1]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/RandomAccessFile.html#setLength(long)
     /\ IF ArrayLen(file_content) > new_length /\ file_pointer > new_length
-    THEN file_pointer' = new_length
-    ELSE file_pointer' \in Offset
+        THEN file_pointer' = new_length
+        ELSE file_pointer' \in Offset
 
 Read(output) ==
     /\ output = ArraySlice(file_content, file_pointer, Min(file_pointer + ArrayLen(output), ArrayLen(file_content)))

--- a/libtlafmt/tests/snapshots/format__corpus@ChangRoberts.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@ChangRoberts.tla.snap
@@ -84,11 +84,11 @@ Init == (* Global variables *)
 n0(self) ==
     /\ pc[self] = "n0"
     /\ IF initiator[self]
-    THEN
-        /\ msgs' = [msgs EXCEPT ![succ(self)] = @ \union {Id[self]}]
-    ELSE
-        /\ TRUE
-        /\ msgs' = msgs
+        THEN
+            /\ msgs' = [msgs EXCEPT ![succ(self)] = @ \union {Id[self]}]
+        ELSE
+            /\ TRUE
+            /\ msgs' = msgs
     /\ pc' = [pc EXCEPT ![self] = "n1"]
     /\ UNCHANGED << initiator, state >>
 
@@ -102,17 +102,17 @@ n1(self) ==
                 /\ state' = state
             ELSE
                 /\ IF id < Id[self]
-                THEN
-                    /\ state' = [state EXCEPT ![self] = "lost"]
-                    /\ msgs' = [_msgs EXCEPT ![succ(self)] = @ \union {id}]
-                ELSE
-                    /\ msgs' = _msgs
-                    /\ IF id = Id[self]
                     THEN
-                        /\ state' = [state EXCEPT ![self] = "won"]
+                        /\ state' = [state EXCEPT ![self] = "lost"]
+                        /\ msgs' = [_msgs EXCEPT ![succ(self)] = @ \union {id}]
                     ELSE
-                        /\ TRUE
-                        /\ state' = state
+                        /\ msgs' = _msgs
+                        /\ IF id = Id[self]
+                            THEN
+                                /\ state' = [state EXCEPT ![self] = "won"]
+                            ELSE
+                                /\ TRUE
+                                /\ state' = state
     /\ pc' = [pc EXCEPT ![self] = "n1"]
     /\ UNCHANGED initiator
 

--- a/libtlafmt/tests/snapshots/format__corpus@ChannelRefinement.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@ChannelRefinement.tla.snap
@@ -20,22 +20,22 @@ VARIABLE bitsSent
 Init ==
     /\ bitsSent = <<>>
     /\ IF L!Init THEN H!Init
-    ELSE h = ErrorVal
+        ELSE h = ErrorVal
 
 SendBit == \E b \in {0, 1}:
-    /\ L!Send(b)
-    /\ IF Len(bitsSent) < 3
-    THEN
-        /\ bitsSent' = << b >> \o bitsSent
-        /\ UNCHANGED h
-    ELSE
-        /\ bitsSent' = <<>>
-        /\ H!Send(BitSeqToNat[<<b>> \o bitsSent])
+        /\ L!Send(b)
+        /\ IF Len(bitsSent) < 3
+            THEN
+                /\ bitsSent' = << b >> \o bitsSent
+                /\ UNCHANGED h
+            ELSE
+                /\ bitsSent' = <<>>
+                /\ H!Send(BitSeqToNat[<<b>> \o bitsSent])
 
 RcvBit ==
     /\ L!Rcv
     /\ IF bitsSent = <<>> THEN H!Rcv
-    ELSE UNCHANGED h
+        ELSE UNCHANGED h
     /\ UNCHANGED bitsSent
 
 Error ==

--- a/libtlafmt/tests/snapshots/format__corpus@CheckpointCoordination.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@CheckpointCoordination.tla.snap
@@ -184,38 +184,38 @@ TypeInvariant ==
 (***************************************************************************)
 SafetyInvariant ==
     /\ Leader /= NoNode =>
-    \* The leader cannot take a checkpoint
-        /\ ~CanTakeCheckpoint[Leader]
-        /\ ~IsTakingCheckpoint[Leader]
-        \* If the leader doesn't know about a lease, neither does any node
-        /\ CurrentLease[Leader] = NoCheckpointLease =>
-            /\ \A n \in Node:
-                /\ ~CanTakeCheckpoint[n]
-                /\ ~IsTakingCheckpoint[n]
-                \* If the leader knows about a lease, only that node can checkpoint
-        /\ CurrentLease[Leader] /= NoCheckpointLease =>
-            /\ \A n \in Node:
-                /\ (CanTakeCheckpoint[n] \/ IsTakingCheckpoint[n]) =>
-                    /\ CurrentLease[Leader].node = n
-                    \* Two nodes can't take a checkpoint simultaneously
+        \* The leader cannot take a checkpoint
+            /\ ~CanTakeCheckpoint[Leader]
+            /\ ~IsTakingCheckpoint[Leader]
+            \* If the leader doesn't know about a lease, neither does any node
+            /\ CurrentLease[Leader] = NoCheckpointLease =>
+                /\ \A n \in Node:
+                    /\ ~CanTakeCheckpoint[n]
+                    /\ ~IsTakingCheckpoint[n]
+                    \* If the leader knows about a lease, only that node can checkpoint
+            /\ CurrentLease[Leader] /= NoCheckpointLease =>
+                    /\ \A n \in Node:
+                        /\ (CanTakeCheckpoint[n] \/ IsTakingCheckpoint[n]) =>
+                            /\ CurrentLease[Leader].node = n
+                            \* Two nodes can't take a checkpoint simultaneously
     /\ \A n1, n2 \in Node:
-            /\ (CanTakeCheckpoint[n1] /\ CanTakeCheckpoint[n2]) =>
-                /\ n1 = n2
-            /\ (IsTakingCheckpoint[n1] /\ IsTakingCheckpoint[n2]) =>
-                /\ n1 = n2
-                \* Prerequisites for taking a checkpoint must be satisfied
+                /\ (CanTakeCheckpoint[n1] /\ CanTakeCheckpoint[n2]) =>
+                        /\ n1 = n2
+                /\ (IsTakingCheckpoint[n1] /\ IsTakingCheckpoint[n2]) =>
+                        /\ n1 = n2
+                        \* Prerequisites for taking a checkpoint must be satisfied
     /\ \A n \in Node:
-            /\ IsTakingCheckpoint[n] => CanTakeCheckpoint[n]
-            /\ CanTakeCheckpoint[n] => (CurrentLease[n] /= NoCheckpointLease)
-            /\ CanTakeCheckpoint[n] => CurrentLease[n].node = n
-            /\ CanTakeCheckpoint[n] => CurrentLease[n].counter >= TimeoutCounter
-            \* Replicated logs can never conflict
+                /\ IsTakingCheckpoint[n] => CanTakeCheckpoint[n]
+                /\ CanTakeCheckpoint[n] => (CurrentLease[n] /= NoCheckpointLease)
+                /\ CanTakeCheckpoint[n] => CurrentLease[n].node = n
+                /\ CanTakeCheckpoint[n] => CurrentLease[n].counter >= TimeoutCounter
+                \* Replicated logs can never conflict
     /\ \A i \in LogIndex:
-            /\ \A n1, n2 \in Node:
-                \/ ReadLog(n1, i) = NoNode
-                \/ ReadLog(n2, i) = NoNode
-                \/ ReadLog(n1, i) = ReadLog(n2, i)
-                
+                /\ \A n1, n2 \in Node:
+                    \/ ReadLog(n1, i) = NoNode
+                    \/ ReadLog(n2, i) = NoNode
+                    \/ ReadLog(n1, i) = ReadLog(n2, i)
+                        
 (***************************************************************************)
 (* Expectations about system capabilities.                                 *)
 (***************************************************************************)
@@ -350,7 +350,7 @@ ShouldReplaceLease(currentLease) ==
     \/
         /\ Connected(Leader, currentLease.node)
         /\ currentLease.counter < LastVotePayload[currentLease.node]
-    
+        
 (***************************************************************************)
 (* The leader designates an arbitrary node to take a checkpoint. This is   *)
 (* done by sending a replicated request to all nodes in the quorum. The    *)
@@ -369,11 +369,11 @@ SendReplicatedRequest(prospect) ==
                     THEN WriteLog(n, index, prospect)
                     ELSE ReplicatedLog[n]]
             /\ CurrentLease' = [
-                CurrentLease EXCEPT ![Leader] = [
-                        node |-> prospect,
-                        counter |-> index
-                    ]
-            ]
+                    CurrentLease EXCEPT ![Leader] = [
+                            node |-> prospect,
+                            counter |-> index
+                        ]
+                ]
             /\ UNCHANGED EnvironmentVars
             /\ UNCHANGED << Leader, ExecutionCounter, LastVotePayload >>
             /\ UNCHANGED << CanTakeCheckpoint, IsTakingCheckpoint, TimeoutCounter, LatestCheckpoint >>
@@ -400,11 +400,11 @@ ProcessReplicatedRequest(n) ==
             /\ ~IsTakingCheckpoint[n]
             /\ request /= NoNode
             /\ CanTakeCheckpoint' = [
-                CanTakeCheckpoint EXCEPT ![n] =
-                    /\ Leader /= n
-                    /\ n = request
-                    /\ ~isTimedOut
-            ]
+                    CanTakeCheckpoint EXCEPT ![n] =
+                        /\ Leader /= n
+                        /\ n = request
+                        /\ ~isTimedOut
+                ]
             /\ CurrentLease' =
                 IF n = Leader
                 THEN CurrentLease
@@ -439,13 +439,13 @@ FinishCheckpoint(n) ==
     /\ CanTakeCheckpoint' = [CanTakeCheckpoint EXCEPT ![n] = FALSE]
     /\ IsTakingCheckpoint' = [IsTakingCheckpoint EXCEPT ![n] = FALSE]
     /\ LatestCheckpoint' = [
-        log |-> SubSeq(
-                ReplicatedLog[n],
-                MinLogIndex,
-                    ExecutionCounter[n] - 1
-            ),
-        counter |-> ExecutionCounter[n]
-    ]
+            log |-> SubSeq(
+                    ReplicatedLog[n],
+                    MinLogIndex,
+                        ExecutionCounter[n] - 1
+                ),
+            counter |-> ExecutionCounter[n]
+        ]
     /\ UNCHANGED EnvironmentVars
     /\ UNCHANGED << Leader, ReplicatedLog, ExecutionCounter >>
     /\ UNCHANGED << TimeoutCounter >>
@@ -460,15 +460,15 @@ TriggerTimeout ==
     /\ \E n \in Node: ReadLog(n, TimeoutCounter) /= NoNode
     /\ TimeoutCounter' = TimeoutCounter + 1
     /\ CanTakeCheckpoint' = [
-        n \in Node |->
-        /\ CanTakeCheckpoint[n]
-        /\ CurrentLease[n].counter > TimeoutCounter
-    ]
+                n \in Node |->
+                /\ CanTakeCheckpoint[n]
+                /\ CurrentLease[n].counter > TimeoutCounter
+        ]
     /\ IsTakingCheckpoint' = [
-        n \in Node |->
-        /\ IsTakingCheckpoint[n]
-        /\ CurrentLease[n].counter > TimeoutCounter
-    ]
+                n \in Node |->
+                /\ IsTakingCheckpoint[n]
+                /\ CurrentLease[n].counter > TimeoutCounter
+        ]
     /\ UNCHANGED EnvironmentVars
     /\ UNCHANGED PaxosVars
     /\ UNCHANGED << CurrentLease, LatestCheckpoint >>

--- a/libtlafmt/tests/snapshots/format__corpus@DijkstraMutex.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@DijkstraMutex.tla.snap
@@ -123,10 +123,10 @@ Li0(self) ==
 Li1(self) ==
     /\ pc[self] = "Li1"
     /\ IF k /= self
-    THEN
-        /\ pc' = [pc EXCEPT ![self] = "Li2"]
-    ELSE
-        /\ pc' = [pc EXCEPT ![self] = "Li4a"]
+        THEN
+            /\ pc' = [pc EXCEPT ![self] = "Li2"]
+        ELSE
+            /\ pc' = [pc EXCEPT ![self] = "Li4a"]
     /\ UNCHANGED << b, c, k, temp >>
 
 Li2(self) ==
@@ -144,10 +144,10 @@ Li3a(self) ==
 Li3b(self) ==
     /\ pc[self] = "Li3b"
     /\ IF b[temp[self]]
-    THEN
-        /\ pc' = [pc EXCEPT ![self] = "Li3c"]
-    ELSE
-        /\ pc' = [pc EXCEPT ![self] = "Li3d"]
+        THEN
+            /\ pc' = [pc EXCEPT ![self] = "Li3c"]
+        ELSE
+            /\ pc' = [pc EXCEPT ![self] = "Li3d"]
     /\ UNCHANGED << b, c, k, temp >>
 
 Li3c(self) ==
@@ -171,17 +171,17 @@ Li4a(self) ==
 Li4b(self) ==
     /\ pc[self] = "Li4b"
     /\ IF temp[self] /= {}
-    THEN
-        /\ \E j \in temp[self]:
-            /\ temp' = [temp EXCEPT ![self] = temp[self] \ {j}]
-            /\ IF ~c[j]
-            THEN
-                /\ pc' = [pc EXCEPT ![self] = "Li1"]
-            ELSE
-                /\ pc' = [pc EXCEPT ![self] = "Li4b"]
-    ELSE
-        /\ pc' = [pc EXCEPT ![self] = "cs"]
-        /\ temp' = temp
+        THEN
+            /\ \E j \in temp[self]:
+                /\ temp' = [temp EXCEPT ![self] = temp[self] \ {j}]
+                /\ IF ~c[j]
+                    THEN
+                        /\ pc' = [pc EXCEPT ![self] = "Li1"]
+                    ELSE
+                        /\ pc' = [pc EXCEPT ![self] = "Li4b"]
+        ELSE
+            /\ pc' = [pc EXCEPT ![self] = "cs"]
+            /\ temp' = temp
     /\ UNCHANGED << b, c, k >>
 
 cs(self) ==

--- a/libtlafmt/tests/snapshots/format__corpus@DiningPhilosophers.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@DiningPhilosophers.tla.snap
@@ -143,13 +143,13 @@ ProcSet == (1..NP)
 
 Init == (* Global variables *)
     /\ forks = [
-        fork \in 1..NP |-> [
-            
-            holder |-> IF fork = 2 THEN 1 ELSE fork,
-            
-            clean |-> FALSE
+                fork \in 1..NP |-> [
+                
+                    holder |-> IF fork = 2 THEN 1 ELSE fork,
+                
+                    clean |-> FALSE
+                ]
         ]
-    ]
     (* Process Philosopher *)
     /\ hungry = [self \in 1..NP |-> TRUE]
     /\ pc = [self \in ProcSet |-> "Loop"]
@@ -157,34 +157,34 @@ Init == (* Global variables *)
 Loop(self) ==
     /\ pc[self] = "Loop"
     /\ IF
-        /\ forks[LeftFork(self)].holder = self
-        /\ ~forks[LeftFork(self)].clean
-    THEN
-        /\ forks' = [forks EXCEPT ![LeftFork(self)] = [
-                holder |-> LeftPhilosopher(self),
-                clean |-> TRUE
-            ]]
-    ELSE
-        /\ IF
-            /\ forks[RightFork(self)].holder = self
-            /\ ~forks[RightFork(self)].clean
+            /\ forks[LeftFork(self)].holder = self
+            /\ ~forks[LeftFork(self)].clean
         THEN
-            /\ forks' = [forks EXCEPT ![RightFork(self)] = [
-                    holder |-> RightPhilosopher(self),
+            /\ forks' = [forks EXCEPT ![LeftFork(self)] = [
+                    holder |-> LeftPhilosopher(self),
                     clean |-> TRUE
                 ]]
         ELSE
+        /\ IF
+                /\ forks[RightFork(self)].holder = self
+                /\ ~forks[RightFork(self)].clean
+            THEN
+                /\ forks' = [forks EXCEPT ![RightFork(self)] = [
+                        holder |-> RightPhilosopher(self),
+                        clean |-> TRUE
+                    ]]
+            ELSE
             /\ TRUE
             /\ forks' = forks
     /\ IF hungry[self]
-    THEN
-        /\ IF CanEat(self)
         THEN
-            /\ pc' = [pc EXCEPT ![self] = "Eat"]
+            /\ IF CanEat(self)
+                THEN
+                    /\ pc' = [pc EXCEPT ![self] = "Eat"]
+                ELSE
+                    /\ pc' = [pc EXCEPT ![self] = "Loop"]
         ELSE
-            /\ pc' = [pc EXCEPT ![self] = "Loop"]
-    ELSE
-        /\ pc' = [pc EXCEPT ![self] = "Think"]
+            /\ pc' = [pc EXCEPT ![self] = "Think"]
     /\ UNCHANGED hungry
 
 Think(self) ==

--- a/libtlafmt/tests/snapshots/format__corpus@DiskSynod.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@DiskSynod.tla.snap
@@ -61,12 +61,12 @@ Phase1or2Write(p, d) ==
 Phase1or2Read(p, d, q) ==
     /\ d \in disksWritten[p]
     /\ IF disk[d][q].mbal < dblock[p].mbal
-    THEN
-        /\ blocksRead' =
-            [blocksRead EXCEPT
-                ![p][d] = @ \union {[block |-> disk[d][q], proc |-> q]}]
-        /\ UNCHANGED << input, output, disk, phase, dblock, disksWritten >>
-    ELSE StartBallot(p)
+        THEN
+            /\ blocksRead' =
+                [blocksRead EXCEPT
+                    ![p][d] = @ \union {[block |-> disk[d][q], proc |-> q]}]
+            /\ UNCHANGED << input, output, disk, phase, dblock, disksWritten >>
+        ELSE StartBallot(p)
 
 EndPhase1or2(p) ==
     /\ IsMajority({d \in disksWritten[p]:
@@ -88,9 +88,9 @@ EndPhase1or2(p) ==
                             ELSE maxBlk.inp]
             /\ UNCHANGED output
         \/
-            /\ phase[p] = 2
-            /\ output' = [output EXCEPT ![p] = dblock[p].inp]
-            /\ UNCHANGED dblock
+                /\ phase[p] = 2
+                /\ output' = [output EXCEPT ![p] = dblock[p].inp]
+                /\ UNCHANGED dblock
     /\ phase' = [phase EXCEPT ![p] = @ + 1]
     /\ InitializePhase(p)
     /\ UNCHANGED << input, disk >>

--- a/libtlafmt/tests/snapshots/format__corpus@EPFailureDetector.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@EPFailureDetector.tla.snap
@@ -126,10 +126,10 @@ Receive(i, incomingMessages) ==
                     ELSE fromLastHeard[i][j]
                 ELSE fromLastHeard[i][j]]]
     /\ delta' = [delta EXCEPT ![i] = [j \in Proc |-> IF
-                /\ j \in suspected[i]
-                /\ \E m \in incomingMessages: m.from = j
-            THEN delta[i][j] + 1
-            ELSE delta[i][j]]]
+                    /\ j \in suspected[i]
+                    /\ \E m \in incomingMessages: m.from = j
+                THEN delta[i][j] + 1
+                ELSE delta[i][j]]]
     /\ suspected' = [suspected EXCEPT ![i] = suspected[i] \ {j \in Proc: (\E msg \in incomingMessages: msg.from = j)}]
     /\ UNCHANGED outgoingMessages
 

--- a/libtlafmt/tests/snapshots/format__corpus@EWD687aPlusCal.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@EWD687aPlusCal.tla.snap
@@ -143,21 +143,21 @@ node(self) ==
                     /\ UNCHANGED parent
         /\ UNCHANGED << terminationDetected, activeSons >>
     \/
-        /\ pendingAck(network, self)
-        /\ network' = receiveAck(network, self)
-        /\ activeSons' = [activeSons EXCEPT ![self] = activeSons[self] - 1]
-        /\ UNCHANGED << terminationDetected, active, parent >>
+            /\ pendingAck(network, self)
+            /\ network' = receiveAck(network, self)
+            /\ activeSons' = [activeSons EXCEPT ![self] = activeSons[self] - 1]
+            /\ UNCHANGED << terminationDetected, active, parent >>
     \/
-        /\ (~active[self] /\ activeSons[self] = 0 /\ parent[self] /= none)
-        /\ IF parent[self] = self
-        THEN
-            /\ terminationDetected' = TRUE
-            /\ UNCHANGED network
-        ELSE
-            /\ network' = sendAck(network, parent[self])
-            /\ UNCHANGED terminationDetected
-        /\ parent' = [parent EXCEPT ![self] = none]
-        /\ UNCHANGED << active, activeSons >>
+            /\ (~active[self] /\ activeSons[self] = 0 /\ parent[self] /= none)
+            /\ IF parent[self] = self
+                THEN
+                    /\ terminationDetected' = TRUE
+                    /\ UNCHANGED network
+                ELSE
+                    /\ network' = sendAck(network, parent[self])
+                    /\ UNCHANGED terminationDetected
+            /\ parent' = [parent EXCEPT ![self] = none]
+            /\ UNCHANGED << active, activeSons >>
 
 Next == (\E self \in Node: node(self))
 

--- a/libtlafmt/tests/snapshots/format__corpus@EWD998PCal.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@EWD998PCal.tla.snap
@@ -123,22 +123,22 @@ node(self) ==
             /\ color' = [color EXCEPT ![self] = "black"]
             /\ network' = dropMsg(network, self, msg)
     \/
-        /\ active' = [active EXCEPT ![self] = FALSE]
-        /\ UNCHANGED << network, color, counter >>
+            /\ active' = [active EXCEPT ![self] = FALSE]
+            /\ UNCHANGED << network, color, counter >>
     \/
-        /\ self /= Initiator
-        /\ \E tok \in pendingMsgs(network, self):
-            /\ tok.type = "tok" /\ ~active[self]
-            /\ network' = passMsg(network, self, tok, self - 1, [type |-> "tok", q |-> tok.q + counter[self], color |-> (IF color[self] = "black" THEN "black" ELSE tok.color)])
-            /\ color' = [color EXCEPT ![self] = "white"]
-        /\ UNCHANGED << active, counter >>
+            /\ self /= Initiator
+            /\ \E tok \in pendingMsgs(network, self):
+                /\ tok.type = "tok" /\ ~active[self]
+                /\ network' = passMsg(network, self, tok, self - 1, [type |-> "tok", q |-> tok.q + counter[self], color |-> (IF color[self] = "black" THEN "black" ELSE tok.color)])
+                /\ color' = [color EXCEPT ![self] = "white"]
+            /\ UNCHANGED << active, counter >>
     \/
-        /\ self = Initiator
-        /\ \E tok \in pendingMsgs(network, self):
-            /\ tok.type = "tok" /\ (color[self] = "black" \/ tok.q + counter[self] /= 0 \/ tok.color = "black")
-            /\ network' = passMsg(network, self, tok, N - 1, [type |-> "tok", q |-> 0, color |-> "white"])
-            /\ color' = [color EXCEPT ![self] = "white"]
-        /\ UNCHANGED << active, counter >>
+            /\ self = Initiator
+            /\ \E tok \in pendingMsgs(network, self):
+                /\ tok.type = "tok" /\ (color[self] = "black" \/ tok.q + counter[self] /= 0 \/ tok.color = "black")
+                /\ network' = passMsg(network, self, tok, N - 1, [type |-> "tok", q |-> 0, color |-> "white"])
+                /\ color' = [color EXCEPT ![self] = "white"]
+            /\ UNCHANGED << active, counter >>
 
 Next == (\E self \in Node: node(self))
 

--- a/libtlafmt/tests/snapshots/format__corpus@EWD998_anim.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@EWD998_anim.tla.snap
@@ -159,8 +159,8 @@ AnimSpec ==
                 ELSE - 1
             ELSE 0]
     /\ inbox = [n \in Node |-> IF n = Initiator \* RingOfNodes[Initiator] 
-        THEN << [type |-> "tok", q |-> 0, color |-> "black"] >>
-        ELSE <<>>] \* with empty channels.
+            THEN << [type |-> "tok", q |-> 0, color |-> "black"] >>
+            ELSE <<>>] \* with empty channels.
     /\ Init!5
     /\ [][\E n \in Node: System(n)]_vars
 

--- a/libtlafmt/tests/snapshots/format__corpus@EWD998_opts.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@EWD998_opts.tla.snap
@@ -79,10 +79,10 @@ PassTokenOpts(i) ==
             /\ "pt2" \in F
             /\ token.color = "black"
     /\ token' = [token EXCEPT !.pos = CASE "pt3" \in F /\ color[i] = "black" -> 0
-            [] "pt4" \in F /\ token.color = "black" -> 0
-            [] OTHER    ->  @ - 1 ,
-        !.q = @ + counter[i],
-        !.color = IF color[i] = "black" THEN "black" ELSE @]
+                    [] "pt4" \in F /\ token.color = "black" -> 0
+                    [] OTHER    ->  @ - 1 ,
+            !.q = @ + counter[i],
+            !.color = IF color[i] = "black" THEN "black" ELSE @]
     /\ color' = [color EXCEPT ![i] = "white"]
     /\ UNCHANGED << active, counter, pending >>
 

--- a/libtlafmt/tests/snapshots/format__corpus@Echo.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Echo.tla.snap
@@ -108,52 +108,52 @@ Init == (* Global variables *)
 n0(self) ==
     /\ pc[self] = "n0"
     /\ IF self = initiator
-    THEN
-        /\ inbox' = multicast(inbox, self, nbrs[self], "m")
-    ELSE
-        /\ TRUE
-        /\ inbox' = inbox
+        THEN
+            /\ inbox' = multicast(inbox, self, nbrs[self], "m")
+        ELSE
+            /\ TRUE
+            /\ inbox' = inbox
     /\ pc' = [pc EXCEPT ![self] = "n1"]
     /\ UNCHANGED << parent, children, rcvd, nbrs >>
 
 n1(self) ==
     /\ pc[self] = "n1"
     /\ IF rcvd[self] < Cardinality(nbrs[self])
-    THEN
-        /\ \E msg \in inbox[self]:
-            LET net == receive(inbox, self, msg) IN
-                /\ rcvd' = [rcvd EXCEPT ![self] = rcvd[self] + 1]
-                /\ IF self /= initiator /\ rcvd' [self] = 1
-                THEN
-                    /\ Assert((msg.kind = "m"),
-                        "Failure of assertion at line 55, column 16.")
-                    /\ parent' = [parent EXCEPT ![self] = msg.sndr]
-                    /\ inbox' = multicast(net, self, nbrs[self] \ {msg.sndr}, "m")
-                ELSE
-                    /\ inbox' = net
-                    /\ UNCHANGED parent
-                /\ IF msg.kind = "c"
-                THEN
-                    /\ children' = [children EXCEPT ![self] = children[self] \union {msg.sndr}]
-                ELSE
-                    /\ TRUE
-                    /\ UNCHANGED children
-        /\ pc' = [pc EXCEPT ![self] = "n1"]
-    ELSE
-        /\ pc' = [pc EXCEPT ![self] = "n2"]
-        /\ UNCHANGED << inbox, parent, children, rcvd >>
+        THEN
+            /\ \E msg \in inbox[self]:
+                LET net == receive(inbox, self, msg) IN
+                    /\ rcvd' = [rcvd EXCEPT ![self] = rcvd[self] + 1]
+                    /\ IF self /= initiator /\ rcvd' [self] = 1
+                        THEN
+                            /\ Assert((msg.kind = "m"),
+                                "Failure of assertion at line 55, column 16.")
+                            /\ parent' = [parent EXCEPT ![self] = msg.sndr]
+                            /\ inbox' = multicast(net, self, nbrs[self] \ {msg.sndr}, "m")
+                        ELSE
+                            /\ inbox' = net
+                            /\ UNCHANGED parent
+                    /\ IF msg.kind = "c"
+                        THEN
+                            /\ children' = [children EXCEPT ![self] = children[self] \union {msg.sndr}]
+                        ELSE
+                            /\ TRUE
+                            /\ UNCHANGED children
+            /\ pc' = [pc EXCEPT ![self] = "n1"]
+        ELSE
+            /\ pc' = [pc EXCEPT ![self] = "n2"]
+            /\ UNCHANGED << inbox, parent, children, rcvd >>
     /\ nbrs' = nbrs
 
 n2(self) ==
     /\ pc[self] = "n2"
     /\ IF self /= initiator
-    THEN
-        /\ Assert((parent[self] \in nbrs[self]),
-            "Failure of assertion at line 70, column 10.")
-        /\ inbox' = send(inbox, self, parent[self], "c")
-    ELSE
-        /\ TRUE
-        /\ inbox' = inbox
+        THEN
+            /\ Assert((parent[self] \in nbrs[self]),
+                "Failure of assertion at line 70, column 10.")
+            /\ inbox' = send(inbox, self, parent[self], "c")
+        ELSE
+            /\ TRUE
+            /\ inbox' = inbox
     /\ pc' = [pc EXCEPT ![self] = "Done"]
     /\ UNCHANGED << parent, children, rcvd, nbrs >>
 

--- a/libtlafmt/tests/snapshots/format__corpus@Elevator.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Elevator.tla.snap
@@ -69,16 +69,16 @@ SafetyInvariant == \* Some more comprehensive checks beyond the type invariant
                 /\ PersonState[p].location = e
                 /\ PersonState[p].destination = f
     /\ \A p \in Person: \* A person is in an elevator only if the elevator is moving toward their destination floor
-            /\ \A e \in Elevator:
-                /\ (PersonState[p].location = e /\ ElevatorState[e].floor /= PersonState[p].destination) =>
-                    /\ ElevatorState[e].direction = GetDirection[ElevatorState[e].floor, PersonState[p].destination]
+                /\ \A e \in Elevator:
+                    /\ (PersonState[p].location = e /\ ElevatorState[e].floor /= PersonState[p].destination) =>
+                        /\ ElevatorState[e].direction = GetDirection[ElevatorState[e].floor, PersonState[p].destination]
     /\ \A c \in ActiveElevatorCalls: PeopleWaiting[c.floor, c.direction] /= {} \* No ghost calls
 
 TemporalInvariant == \* Expectations about elevator system capabilities
     /\ \A c \in ElevatorCall: \* Every call is eventually serviced by an elevator
-            /\ c \in ActiveElevatorCalls ~> \E e \in Elevator: CanServiceCall[e, c]
+                /\ c \in ActiveElevatorCalls ~> \E e \in Elevator: CanServiceCall[e, c]
     /\ \A p \in Person: \* If a person waits for their elevator, they'll eventually arrive at their floor
-            /\ PersonState[p].waiting ~> PersonState[p].location = PersonState[p].destination
+                /\ PersonState[p].waiting ~> PersonState[p].location = PersonState[p].destination
 
 PickNewDestination(p) == \* Person decides they need to go to a different floor
     LET pState == PersonState[p] IN

--- a/libtlafmt/tests/snapshots/format__corpus@EnvironmentController.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@EnvironmentController.tla.snap
@@ -236,7 +236,7 @@ ProcTick ==
     \E i \in Proc:
         \/
             /\ failed[i] = TRUE
-        
+            
             /\ UNCHANGED envVars
             /\ CommChan!Deliver(i) (* Some messages are delivery to a process p_i. *)
             /\ UNCHANGED procVars  (* However, p_i cannot receive those messages because
@@ -259,7 +259,7 @@ ProcTick ==
                     /\ moved' = [moved EXCEPT ![i] = "RECEIVE"]
                     /\ CommChan!Deliver(i)
                     /\ Detector!Receive(i, inDelivery')
-                
+                            
 (* Two constraints PHIConstraint and DELTAConstraint are respectively restrictions on
    message delay and relative speeds of processes in partial synchronoy. We use these 
    constraints to filter out executions. Only executions satisfying these constraints

--- a/libtlafmt/tests/snapshots/format__corpus@FastPaxos.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@FastPaxos.tla.snap
@@ -51,7 +51,7 @@ FastAny ==
         /\ SendMessage([type |-> "P2a",
             ballot |-> f,
             value |-> any])
-        
+            
 (*
     Phase 2b (Fast):
 
@@ -71,7 +71,7 @@ FastPropose ==
             ballot |-> m.ballot,
             acceptor |-> a,
             value |-> v])
-        
+            
 (*
     A value is chosen if a fast quorum of acceptors proposed that value in a fast round.
 
@@ -88,7 +88,7 @@ FastDecide ==
             /\ \A a \in q: \E m \in M: m.acceptor = a
             /\ 1 = Cardinality(V)
             /\ \E m \in M: decision' = m.value
-            
+                
 (*
     Phase 2a (Classic)
 
@@ -112,12 +112,12 @@ ClassicAccept ==
             /\ \A a \in q: \E m \in M: m.acceptor = a
             /\ 1 < Cardinality(V) \* Collision occurred.
             /\ IF \E w \in V: IsMajorityValue(M, w)
-            THEN IsMajorityValue(M, v) \* Choose majority in quorum.
-            ELSE v \in V \* Choose any.
+                THEN IsMajorityValue(M, v) \* Choose majority in quorum.
+                ELSE v \in V \* Choose any.
             /\ SendMessage([type |-> "P2a",
                 ballot |-> b,
                 value |-> v])
-                
+                        
 (*
     Phase 2b (Classic)
 

--- a/libtlafmt/tests/snapshots/format__corpus@FindHighest.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@FindHighest.tla.snap
@@ -45,13 +45,13 @@ Init == (* Global variables *)
 lb ==
     /\ pc = "lb"
     /\ IF i <= Len(f)
-    THEN
-        /\ h' = max(h, f[i])
-        /\ i' = i + 1
-        /\ pc' = "lb"
-    ELSE
-        /\ pc' = "Done"
-        /\ UNCHANGED << h, i >>
+        THEN
+            /\ h' = max(h, f[i])
+            /\ i' = i + 1
+            /\ pc' = "lb"
+        ELSE
+            /\ pc' = "Done"
+            /\ UNCHANGED << h, i >>
     /\ f' = f
 
 (* Allow infinite stuttering to prevent deadlock on termination. *)

--- a/libtlafmt/tests/snapshots/format__corpus@Hanoi.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Hanoi.tla.snap
@@ -47,7 +47,7 @@ TypeOK ==
     /\ \A i \in DOMAIN towers:
         /\ towers[i] \in Nat \* Towers are represented by natural numbers
         /\ towers[i] < 2 ^ D
-        
+            
 (***************************************************************************)
 (* Now we define of the initial predicate, that specifies the initial      *)
 (* values of the variables.                                                *)

--- a/libtlafmt/tests/snapshots/format__corpus@InternalMemory.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@InternalMemory.tla.snap
@@ -29,8 +29,8 @@ Req(p) ==
 Do(p) ==
     /\ ctl[p] = "busy"
     /\ mem' = IF buf[p].op = "Wr"
-    THEN [mem EXCEPT ![buf[p].adr] = buf[p].val]
-    ELSE mem
+        THEN [mem EXCEPT ![buf[p].adr] = buf[p].val]
+        ELSE mem
     /\ buf' = [buf EXCEPT ![p] = IF buf[p].op = "Wr"
         THEN NoVal
         ELSE mem[buf[p].adr]]

--- a/libtlafmt/tests/snapshots/format__corpus@KVsnap.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@KVsnap.tla.snap
@@ -130,14 +130,14 @@ UPDATE(self) ==
 COMMIT(self) ==
     /\ pc[self] = "COMMIT"
     /\ IF missed[self] \intersect write_keys[self] = {}
-    THEN
-        /\ tx' = tx \ {self}
-        /\ missed' = [o \in TxId |-> IF o \in tx' THEN missed[o] \union write_keys[self] ELSE missed[o]]
-        /\ store' = [k \in Key |-> IF k \in write_keys[self] THEN snapshotStore[self][k] ELSE store[k]]
-        /\ ops' = [ops EXCEPT ![self] = ops[self] \o SetToSeq({wOp(k, self): k \in write_keys[self]})]
-    ELSE
-        /\ TRUE
-        /\ UNCHANGED << store, tx, missed, ops >>
+        THEN
+            /\ tx' = tx \ {self}
+            /\ missed' = [o \in TxId |-> IF o \in tx' THEN missed[o] \union write_keys[self] ELSE missed[o]]
+            /\ store' = [k \in Key |-> IF k \in write_keys[self] THEN snapshotStore[self][k] ELSE store[k]]
+            /\ ops' = [ops EXCEPT ![self] = ops[self] \o SetToSeq({wOp(k, self): k \in write_keys[self]})]
+        ELSE
+            /\ TRUE
+            /\ UNCHANGED << store, tx, missed, ops >>
     /\ pc' = [pc EXCEPT ![self] = "Done"]
     /\ UNCHANGED << snapshotStore, read_keys, write_keys >>
 

--- a/libtlafmt/tests/snapshots/format__corpus@LamportMutex.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@LamportMutex.tla.snap
@@ -112,7 +112,7 @@ ReceiveRequest(p, q) ==
         /\ network' = [network EXCEPT ![q][p] = Tail(@),
             ![p][q] = Append(@, AckMessage)]
         /\ UNCHANGED << ack, crit >>
-        
+            
 (***************************************************************************)
 (* Process p receives an acknowledgement from q.                           *)
 (***************************************************************************)
@@ -124,7 +124,7 @@ ReceiveAck(p, q) ==
             /\ ack' = [ack EXCEPT ![p] = @ \union {q}]
             /\ network' = [network EXCEPT ![q][p] = Tail(@)]
             /\ UNCHANGED << clock, req, crit >>
-        
+            
 (**************************************************************************)
 (* Process p enters the critical section.                                 *)
 (**************************************************************************)
@@ -156,7 +156,7 @@ ReceiveRelease(p, q) ==
             /\ req' = [req EXCEPT ![p][q] = 0]
             /\ network' = [network EXCEPT ![q][p] = Tail(@)]
             /\ UNCHANGED << clock, ack, crit >>
-        
+            
 (***************************************************************************)
 (* Next-state relation.                                                    *)
 (***************************************************************************)

--- a/libtlafmt/tests/snapshots/format__corpus@LeastCircularSubstring.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@LeastCircularSubstring.tla.snap
@@ -72,10 +72,10 @@ Init == (* Global variables *)
 L3 ==
     /\ pc = "L3"
     /\ IF j < 2 * n
-    THEN
-        /\ pc' = "L5"
-    ELSE
-        /\ pc' = "Done"
+        THEN
+            /\ pc' = "L5"
+        ELSE
+            /\ pc' = "Done"
     /\ UNCHANGED << b, n, f, i, j, k >>
 
 L5 ==
@@ -87,19 +87,19 @@ L5 ==
 L6 ==
     /\ pc = "L6"
     /\ IF b[j % n] /= b[(k + i + 1) % n] /\ i /= nil
-    THEN
-        /\ pc' = "L7"
-    ELSE
-        /\ pc' = "L10"
+        THEN
+            /\ pc' = "L7"
+        ELSE
+            /\ pc' = "L10"
     /\ UNCHANGED << b, n, f, i, j, k >>
 
 L7 ==
     /\ pc = "L7"
     /\ IF b[j % n] < b[(k + i + 1) % n]
-    THEN
-        /\ pc' = "L8"
-    ELSE
-        /\ pc' = "L9"
+        THEN
+            /\ pc' = "L8"
+        ELSE
+            /\ pc' = "L9"
     /\ UNCHANGED << b, n, f, i, j, k >>
 
 L8 ==
@@ -117,19 +117,19 @@ L9 ==
 L10 ==
     /\ pc = "L10"
     /\ IF b[j % n] /= b[(k + i + 1) % n] /\ i = nil
-    THEN
-        /\ pc' = "L11"
-    ELSE
-        /\ pc' = "L14"
+        THEN
+            /\ pc' = "L11"
+        ELSE
+            /\ pc' = "L14"
     /\ UNCHANGED << b, n, f, i, j, k >>
 
 L11 ==
     /\ pc = "L11"
     /\ IF b[j % n] < b[(k + i + 1) % n]
-    THEN
-        /\ pc' = "L12"
-    ELSE
-        /\ pc' = "L13"
+        THEN
+            /\ pc' = "L12"
+        ELSE
+            /\ pc' = "L13"
     /\ UNCHANGED << b, n, f, i, j, k >>
 
 L12 ==

--- a/libtlafmt/tests/snapshots/format__corpus@LevelSpec.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@LevelSpec.tla.snap
@@ -831,18 +831,18 @@ TypeOK ==
                     /\ \A j \in 1..n.numberOfArgs:
                         Len(n.opLevelCond[i][j]) =
                         Node[n.params[i]].numberOfArgs
-            
+                
             /\ (n \in OpDeclNode) =>
-                /\ (n.kind = "ConstantDeclNode") => (n.level = 0)
-                /\ (n.kind = "VariableDeclNode") =>
-                    /\ n.level = 1
-                    /\ n.numberOfArgs = 0
-            
+                    /\ (n.kind = "ConstantDeclNode") => (n.level = 0)
+                    /\ (n.kind = "VariableDeclNode") =>
+                        /\ n.level = 1
+                        /\ n.numberOfArgs = 0
+                
             /\ (n \in OpApplNode) =>
-            (Len(n.args) = Node[n.operator].numberOfArgs)
-            
+                (Len(n.args) = Node[n.operator].numberOfArgs)
+                
             /\ (n \in SubstitutionNode) => (Len(n.subFor) = Len(n.subWith))
-            
+                
             /\ (n \in InstanceNode) =>
                 /\ n.numberOfArgs = Len(n.params)
                 /\ (********************************************************)
@@ -989,7 +989,7 @@ SubstituteInLevelConstraint(rcd, subst) ==
                     {i \in paramNums:
                         /\ IsOpParam(i)
                         /\ Node[subst.subWith[i]].ref \in
-                        OpDefNodeId}
+                            OpDefNodeId}
                 IN UNION {Sub(lc): lc \in rcd.levelConstraints}
                     \union
                     UNION {{LC(i, alp): alp \in SubALP(i)}: i \in OpDefParams},
@@ -1136,22 +1136,22 @@ ModuleNodeLevelCorrect(n) ==
             \A id \in n.assumes: Node[id].level = 0
     
         /\ n.levelConstraints =
-        UNION {Node[opid].levelConstraints: opid \in allDefs}
+            UNION {Node[opid].levelConstraints: opid \in allDefs}
     
         /\ n.argLevelConstraints =
-        UNION {Node[opid].argLevelConstraints: opid \in allDefs}
+            UNION {Node[opid].argLevelConstraints: opid \in allDefs}
     
         /\ n.argLevelParams =
-        (****************************************************************)
+            (****************************************************************)
             (* We must remove the constraints on formal parameters of the   *)
             (* definitions.                                                 *)
             (****************************************************************)
-            (UNION {ReducedLevelConstraint(
-                Node[opid],
-                    defParams(opid)).argLevelParams:
-                opid \in n.opDefs})
-            \union
-            UNION {Node[opid].argLevelParams: opid \in nonDefs}
+                (UNION {ReducedLevelConstraint(
+                    Node[opid],
+                        defParams(opid)).argLevelParams:
+                    opid \in n.opDefs})
+                \union
+                UNION {Node[opid].argLevelParams: opid \in nonDefs}
 
 InstanceNodeLevelCorrect(n) ==
     (*************************************************************************)
@@ -1235,41 +1235,41 @@ InstanceNodeLevelCorrect(n) ==
           (* A level-constraint on mparam[i] implies a condition on         *)
           (* mexp[i].                                                       *)
           (******************************************************************)
-            \A i \in 1..r:
-                mexp[i].level <=
-                    MinLevelConstraint(mparamId[i], M.levelConstraints)
+                \A i \in 1..r:
+                    mexp[i].level <=
+                        MinLevelConstraint(mparamId[i], M.levelConstraints)
     
         /\ (******************************************************************)
           (* If mexp[i] is a defined operator argument, then an arg-level   *)
           (* constraint on mparam[i] implies a condition on mexp[i].        *)
           (******************************************************************)
-            \A i \in 1..r:
-                    /\ mparam[i].numberOfArgs > 0
-                    /\ mOpArg(i) \in OpDefNode
-                    (***************************************************************)
+                \A i \in 1..r:
+                        /\ mparam[i].numberOfArgs > 0
+                        /\ mOpArg(i) \in OpDefNode
+                        (***************************************************************)
              (* IF param[i] is an operator argument and mexp[i] is a        *)
              (* defined operator,                                           *)
              (***************************************************************)
-                => (************************************************************)
+                    => (************************************************************)
                 (* THEN the operator mexp[i] must satisfy the arg-level     *)
                 (* constraints on param[i].                                 *)
                 (************************************************************)
-                \A j \in 1..mOpArg(i).numberOfArgs:
-                    mOpArg(i).maxLevels[j] >=
-                        MaxArgLevelConstraints(mparamId[i],
-                            M.argLevelConstraints)[j]
+                    \A j \in 1..mOpArg(i).numberOfArgs:
+                        mOpArg(i).maxLevels[j] >=
+                            MaxArgLevelConstraints(mparamId[i],
+                                M.argLevelConstraints)[j]
         /\ (******************************************************************)
           (* An arg-level parameter of M asserting that param[j] appears in *)
           (* an argument of operator parameter param[i], where mexp[i] is a *)
           (* defined operator, implies a condition relating mexp[i] and     *)
           (* mexp[j].                                                       *)
           (******************************************************************)
-            \A alp \in M.argLevelParams:
-                \A i, j \in 1..r:
-                        /\ alp.op = mparamId[i]
-                        /\ alp.param = mparamId[j]
-                        /\ mOpArg(i) \in OpDefNode
-                    => (mexp[j].level <= mOpArg(i).maxLevels[alp.idx])
+                \A alp \in M.argLevelParams:
+                    \A i, j \in 1..r:
+                            /\ alp.op = mparamId[i]
+                            /\ alp.param = mparamId[j]
+                            /\ mOpArg(i) \in OpDefNode
+                        => (mexp[j].level <= mOpArg(i).maxLevels[alp.idx])
     
         (*********************************************************************)
        (* The level constraints for InstanceNode n are the ones that come   *)
@@ -1278,14 +1278,14 @@ InstanceNodeLevelCorrect(n) ==
        (* removed.                                                          *)
        (*********************************************************************)
         /\ n.levelConstraints =
-            redMSubConstraints.levelConstraints \union
-            UNION {redMexp[i].levelConstraints: i \in 1..r}
+                redMSubConstraints.levelConstraints \union
+                UNION {redMexp[i].levelConstraints: i \in 1..r}
         /\ n.argLevelConstraints =
-            redMSubConstraints.argLevelConstraints \union
-            UNION {redMexp[i].argLevelConstraints: i \in 1..r}
+                redMSubConstraints.argLevelConstraints \union
+                UNION {redMexp[i].argLevelConstraints: i \in 1..r}
         /\ n.argLevelParams =
-            redMSubConstraints.argLevelParams \union
-            UNION {redMexp[i].argLevelParams: i \in 1..r}
+                redMSubConstraints.argLevelParams \union
+                UNION {redMexp[i].argLevelParams: i \in 1..r}
 
 OpDefNodeLevelCorrect(n) ==
     (*************************************************************************)
@@ -1353,19 +1353,19 @@ OpDefNodeLevelCorrect(n) ==
 
     IN
         /\ n.level =
-        (****************************************************************)
+            (****************************************************************)
             (* The level of Op is the maximum of                            *)
             (*   - The level of exp, and                                    *)
             (*   - The levels of all mexp[i] such that mparam[i]            *)
             (*     contributes  to the level of exp.                        *)
             (****************************************************************)
-            LET pLevel(i) == IF mparamId[i] \in subExp.levelParams
-            THEN mexp[i].level
-            ELSE 0
-            IN NumMax(exp.level, SetMax({pLevel(i): i \in 1..r}))
+                LET pLevel(i) == IF mparamId[i] \in subExp.levelParams
+                THEN mexp[i].level
+                ELSE 0
+                IN NumMax(exp.level, SetMax({pLevel(i): i \in 1..r}))
     
         /\ n.maxLevels =
-        (****************************************************************)
+            (****************************************************************)
             (* n.maxLevels[i] is determined by the level constraints on     *)
             (* param[i] that come from subExp and from the mexp[j].  (The   *)
             (* latter constraints can only be on param[i] with i \leq q.)   *)
@@ -1378,35 +1378,35 @@ OpDefNodeLevelCorrect(n) ==
             (* the level of subExp (and hence the parameter doesn't occur   *)
             (* in subExp.levelParams).                                      *)
             (****************************************************************)
-            [i \in 1..p |->
-                MinLevelConstraint(
-                    param[i],
-                        subExp.levelConstraints \union
-                        UNION {mexp[j].levelConstraints: j \in 1..r})]
+                [i \in 1..p |->
+                    MinLevelConstraint(
+                        param[i],
+                            subExp.levelConstraints \union
+                            UNION {mexp[j].levelConstraints: j \in 1..r})]
     
         /\ n.weights =
-        (****************************************************************)
+            (****************************************************************)
             (* n.weights[i] is 1 iff param[i] is a level parameter of       *)
             (* subExp.                                                      *)
             (****************************************************************)
-            [i \in 1..p |-> IF param[i] \in subExp.levelParams THEN 1 ELSE 0]
+                [i \in 1..p |-> IF param[i] \in subExp.levelParams THEN 1 ELSE 0]
     
         /\ n.minMaxLevel =
-        (****************************************************************)
+            (****************************************************************)
             (* n.minMaxLevel[i] is deduced from the arg-level constraints   *)
             (* on param[i] obtained from subExp and (for i \leq r) from the *)
             (* mexp[j].  As with n.maxLevels, this is conservative,         *)
             (* essentially assuming that any INSTANCE parameter could       *)
             (* appear in subExp.                                            *)
             (****************************************************************)
-            [i \in 1..p |->
-                MaxArgLevelConstraints(
-                    param[i],
-                        subExp.argLevelConstraints \union
-                        UNION {mexp[j].argLevelConstraints: j \in 1..r})]
+                [i \in 1..p |->
+                    MaxArgLevelConstraints(
+                        param[i],
+                            subExp.argLevelConstraints \union
+                            UNION {mexp[j].argLevelConstraints: j \in 1..r})]
     
         /\ n.opLevelCond =
-        (****************************************************************)
+            (****************************************************************)
             (* n.opLevelCond[i][j][k] is true iff there is an element of    *)
             (* subExp.argLevelParams indicating that param[j] occurs inside *)
             (* the k-th argument of an instance of param[i] in subExp or in *)
@@ -1415,12 +1415,12 @@ OpDefNodeLevelCorrect(n) ==
             (* that come from mexp[h] involve only the first r formal       *)
             (* parameters.                                                  *)
             (****************************************************************)
-            [i \in 1..p |->
-                [j \in 1..p |->
-                    [k \in 1..Node[param[i]].numberOfArgs |->
-                        [op |-> param[i], idx |-> k, param |-> param[j]]
-                        \in subExp.argLevelParams \union
-                            UNION {mexp[h].argLevelParams: h \in 1..r}]]]
+                [i \in 1..p |->
+                    [j \in 1..p |->
+                        [k \in 1..Node[param[i]].numberOfArgs |->
+                            [op |-> param[i], idx |-> k, param |-> param[j]]
+                            \in subExp.argLevelParams \union
+                                UNION {mexp[h].argLevelParams: h \in 1..r}]]]
     
         /\ n.levelParams = subExp.levelParams \ paramIds
         (****************************************************************)
@@ -1429,25 +1429,25 @@ OpDefNodeLevelCorrect(n) ==
             (****************************************************************)
     
         /\ n.levelConstraints =
-        (****************************************************************)
+            (****************************************************************)
             (* The level constraints of Op are the ones from subExp that    *)
             (* don't constrain its formal parameters.  The level            *)
             (* constraints that come from the mexp[j] belong to the         *)
             (* INSTANCE node.                                               *)
             (****************************************************************)
-        {lc \in subExp.levelConstraints: lc.param \notin paramIds}
+            {lc \in subExp.levelConstraints: lc.param \notin paramIds}
     
         /\ n.argLevelConstraints =
-        (****************************************************************)
+            (****************************************************************)
             (* The arg-level constraints of Op are the ones from subExp     *)
             (* that don't constraint its formal parameters.  Again, the     *)
             (* arg-level constraints that come from the mexp[j] belong to   *)
             (* the INSTANCE node.                                           *)
             (****************************************************************)
-        {alc \in subExp.argLevelConstraints: alc.param \notin paramIds}
+            {alc \in subExp.argLevelConstraints: alc.param \notin paramIds}
     
         /\ n.argLevelParams =
-        (****************************************************************)
+            (****************************************************************)
             (* The arg-level parameters of Op are the ones from subExp such *)
             (* that the op and params fields are not both formal parameters *)
             (* of Op, and the ones from the mexp[j] in which exactly one of *)
@@ -1459,17 +1459,17 @@ OpDefNodeLevelCorrect(n) ==
             (* parameters.  Such conservatism seems necessary--for example, *)
             (* in case the INSTANCE occurs within a LET.                    *)
             (****************************************************************)
-            {alp \in subExp.argLevelParams:
-                \/ alp.op \notin paramIds
-                \/ alp.param \notin paramIds}
-            \union
-            {alp \in UNION {mexp[j].argLevelParams: j \in 1..r}:
-                \/
-                    /\ alp.op \in paramIds
-                    /\ alp.param \notin paramIds
-                \/
-                    /\ alp.op \notin paramIds
-                    /\ alp.param \in paramIds}
+                {alp \in subExp.argLevelParams:
+                    \/ alp.op \notin paramIds
+                    \/ alp.param \notin paramIds}
+                \union
+                {alp \in UNION {mexp[j].argLevelParams: j \in 1..r}:
+                    \/
+                        /\ alp.op \in paramIds
+                        /\ alp.param \notin paramIds
+                    \/
+                        /\ alp.op \notin paramIds
+                        /\ alp.param \in paramIds}
     
         (***************************************************************************)
  (* The definition of OpApplNodeLevelCorrect is rather complicated.  There  *)
@@ -1516,45 +1516,45 @@ DeclaredOpApplNodeLevelCorrect(n) ==
             (* Corrected (I hope) on 24 Mar 2007 by LL to include op.level. *)
             (****************************************************************)
         /\ n.levelParams =
-        (****************************************************************)
+            (****************************************************************)
             (* The level parameters of n are the Op itself and the          *)
             (* LevelParams of all the arguments.                            *)
             (****************************************************************)
-            {opid} \union UNION {arg[i].levelParams: i \in 1..p}
+                {opid} \union UNION {arg[i].levelParams: i \in 1..p}
     
         /\ n.levelConstraints =
-        (****************************************************************)
+            (****************************************************************)
             (* The LevelConstraints of n are all obtained from its          *)
             (* arguments.                                                   *)
             (****************************************************************)
-        UNION {arg[i].levelConstraints: i \in 1..p}
+            UNION {arg[i].levelConstraints: i \in 1..p}
     
         /\ n.argLevelConstraints =
-        (****************************************************************)
+            (****************************************************************)
             (* There are two source of arg-level constraints for n: the     *)
             (* ones it implies about Op, and the ones it inherits from its  *)
             (* arguments.                                                   *)
             (****************************************************************)
-            {[op |-> opid, idx |-> i, level |-> arg[i].level]: i \in 1..p}
-            \union
-            UNION {arg[i].argLevelConstraints: i \in 1..p}
+                {[op |-> opid, idx |-> i, level |-> arg[i].level]: i \in 1..p}
+                \union
+                UNION {arg[i].argLevelConstraints: i \in 1..p}
     
         /\ n.argLevelParams =
-        (****************************************************************)
+            (****************************************************************)
             (* There are two source of arg-level parameters for n: the ones *)
             (* it implies about Op, and the ones it inherits from its       *)
             (* arguments.                                                   *)
             (****************************************************************)
-            (LET ALP(i) ==
-                (*********************************************************)
+                (LET ALP(i) ==
+                    (*********************************************************)
                    (* The arg-level parameters implied about Op by the i-th *)
                    (* argument of n.                                        *)
                    (*********************************************************)
-                    {[op |-> opid, idx |-> i, param |-> par]:
-                        par \in arg[i].levelParams}
-                IN UNION {ALP(i): i \in 1..p})
-            \union
-            UNION {arg[i].argLevelParams: i \in 1..p}
+                        {[op |-> opid, idx |-> i, param |-> par]:
+                            par \in arg[i].levelParams}
+                    IN UNION {ALP(i): i \in 1..p})
+                \union
+                UNION {arg[i].argLevelParams: i \in 1..p}
 
 DefinedOpApplNodeLevelCorrect(n) ==
     (*************************************************************************)
@@ -1615,19 +1615,19 @@ DefinedOpApplNodeLevelCorrect(n) ==
                 (***********************************************************)
                  (* The level of arg[i] must be \leq op.maxLevels[i].       *)
                  (***********************************************************)
-            
+                
                 /\
-                    /\ IsOpArg(op, i)
-                    (********************************************************)
+                        /\ IsOpArg(op, i)
+                        (********************************************************)
                     (* IF arg[i] is an operator argument oparg ...          *)
                     (********************************************************)
-                    /\ arg[i].ref \in OpDefNodeId
-                    (********************************************************)
+                        /\ arg[i].ref \in OpDefNodeId
+                        (********************************************************)
                     (* ...  that is defined (rather than declared) [and     *)
                     (* hence is an IdentifierNode whose ref field is an     *)
                     (* OpDefOrDeclNodeId].)  THEN                           *)
                     (********************************************************)
-                =>
+                    =>
                     /\ (*******************************************************)
                      (* oparg must be able to take a k-th argument of level *)
                      (* at least op.minMaxLevel[k].                         *)
@@ -1644,33 +1644,33 @@ DefinedOpApplNodeLevelCorrect(n) ==
                      (* able to take a k-th argument of level at least      *)
                      (* equal to the level of arg[j].                       *)
                      (*******************************************************)
-                        \A j \in 1..p:
-                            \A k \in 1..numOpArgs(i):
-                                op.opLevelCond[i][j][k] =>
-                                    arg[j].level <= arg[i].maxLevels[k]
+                            \A j \in 1..p:
+                                \A k \in 1..numOpArgs(i):
+                                    op.opLevelCond[i][j][k] =>
+                                        arg[j].level <= arg[i].maxLevels[k]
     
         /\ n.level =
-        (****************************************************************)
+            (****************************************************************)
             (* The maximum of op.level and the levels of all the arguments  *)
             (* whose corresponding weights are 1.                           *)
             (****************************************************************)
-            NumMax(op.level,
-                    SetMax({arg[i].level * op.weights[i]: i \in 1..p}))
+                NumMax(op.level,
+                        SetMax({arg[i].level * op.weights[i]: i \in 1..p}))
     
         /\ n.levelParams =
-        (****************************************************************)
+            (****************************************************************)
             (* The parameters that contribute to the level of expression n  *)
             (* are the ones contributing to the level of op, together with  *)
             (* the ones contributing to the level of each argument that has *)
             (* weight 1.                                                    *)
             (****************************************************************)
-            op.levelParams \union
-                LET LP(i) == IF op.weights[i] = 1 THEN arg[i].levelParams
-                ELSE {}
-                IN UNION {LP(i): i \in 1..p}
+                op.levelParams \union
+                    LET LP(i) == IF op.weights[i] = 1 THEN arg[i].levelParams
+                    ELSE {}
+                    IN UNION {LP(i): i \in 1..p}
     
         /\ n.levelConstraints =
-        (****************************************************************)
+            (****************************************************************)
             (* Level constraints obtained from the expression arise from    *)
             (* the following sources:                                       *)
             (****************************************************************)
@@ -1678,24 +1678,24 @@ DefinedOpApplNodeLevelCorrect(n) ==
             (* 1. op.levelConstraints :                                     *)
             (*      Constraints inherited from the definition of op.        *)
             (****************************************************************)
-            op.levelConstraints
-            \union
-            (****************************************************************)
+                op.levelConstraints
+                \union
+                (****************************************************************)
             (* 2. arg[i].levelConstraints :                                 *)
             (*      Constraints inherited from each argument arg[i].        *)
             (****************************************************************)
-            (UNION {arg[i].levelConstraints: i \in 1..p})
-            \union
-            (****************************************************************)
+                (UNION {arg[i].levelConstraints: i \in 1..p})
+                \union
+                (****************************************************************)
             (* 3. op.maxLevels[i] :                                         *)
             (*      If a parameter par contributes to the level of arg[i],  *)
             (*      then the level of par must be \leq op.maxLevels[i].     *)
             (****************************************************************)
-            (LET LC(i) == {[param |-> par, level |-> op.maxLevels[i]]:
-                        par \in arg[i].levelParams}
-                IN UNION {LC(i): i \in 1..p})
-            \union
-            (****************************************************************)
+                (LET LC(i) == {[param |-> par, level |-> op.maxLevels[i]]:
+                            par \in arg[i].levelParams}
+                    IN UNION {LC(i): i \in 1..p})
+                \union
+                (****************************************************************)
             (* 4. op.opLevelCond :                                          *)
             (*      If param[i] is an operator parameter, arg[i] is         *)
             (*      a defined operator opArg, and param[j] contributes to   *)
@@ -1704,52 +1704,52 @@ DefinedOpApplNodeLevelCorrect(n) ==
             (*      contributing to the level of arg[j] must have level at  *)
             (*      most opArg.maxlevels[k].                                *)
             (****************************************************************)
-            (LET LC(i, j, k) ==
-                (*************************************************************)
+                (LET LC(i, j, k) ==
+                    (*************************************************************)
                (* The set of level constraints that would be implied if a   *)
                (* parameter contributes to the level of arg[j], and         *)
                (* param[j] appears as the k-th argument of some instance of *)
                (* param[i] in the definition of the operator arg[i].        *)
                (*************************************************************)
-                    {[param |-> par, level |-> Node[arg[i].ref].maxLevels[k]]:
-                        par \in arg[j].levelParams}
-                    LCE(i, j) ==
-                    (*********************************************************)
+                        {[param |-> par, level |-> Node[arg[i].ref].maxLevels[k]]:
+                            par \in arg[j].levelParams}
+                        LCE(i, j) ==
+                        (*********************************************************)
                    (* The set of level constraints in all LC(i,j,k) such    *)
                    (* that param[i] is an operator parameter that takes at  *)
                    (* least k-th arguments, and op.opLevelCond[i][j][k]     *)
                    (* implies that param[j] appears as in k-th argument of  *)
                    (* some instance of param[i] in the definition of Op.    *)
                    (*********************************************************)
-                    UNION {LC(i, j, k): k \in OpLevelCondIdx(i, j)}
-                IN UNION {LCE(i, j): i \in defOpArgs, j \in 1..p})
-            \union
-            (****************************************************************)
+                        UNION {LC(i, j, k): k \in OpLevelCondIdx(i, j)}
+                    IN UNION {LCE(i, j): i \in defOpArgs, j \in 1..p})
+                \union
+                (****************************************************************)
             (* 5. op.argLevelParams :                                       *)
             (*      For any arg-level parameter alp in op.argLevelParams,   *)
             (*      if alp.op = param[i] and arg[i] is a defined operator   *)
             (*      opArg, then the level of op.param must be \leq          *)
             (*      opArg.maxLevels[alp.idx].                               *)
             (****************************************************************)
-            (LET
-                    ALP(i) ==
-                    (*********************************************************)
+                (LET
+                        ALP(i) ==
+                        (*********************************************************)
                    (* The set of arg-level parameters in op.argLevelParams  *)
                    (* whose op field is param[i].                           *)
                    (*********************************************************)
-                    {alp \in op.argLevelParams: alp.op = param[i]}
-                    LC(i) ==
-                    (*********************************************************)
+                        {alp \in op.argLevelParams: alp.op = param[i]}
+                        LC(i) ==
+                        (*********************************************************)
                    (* The level constraints implied by the elements in      *)
                    (* ALP(i).                                               *)
                    (*********************************************************)
-                        {[param |-> alp.param,
-                            level |-> Node[arg[i].ref].maxLevels[alp.idx]]:
-                            alp \in ALP(i)}
-                IN UNION {LC(i): i \in defOpArgs})
-        
-        /\ n.argLevelConstraints =
-            (****************************************************************)
+                            {[param |-> alp.param,
+                                level |-> Node[arg[i].ref].maxLevels[alp.idx]]:
+                                alp \in ALP(i)}
+                    IN UNION {LC(i): i \in defOpArgs})
+            
+            /\ n.argLevelConstraints =
+                (****************************************************************)
             (* Arg-level constraints implied by the expression arise from   *)
             (* the following sources:                                       *)
             (****************************************************************)
@@ -1758,54 +1758,54 @@ DefinedOpApplNodeLevelCorrect(n) ==
             (*      Expression n inherits arg-level constraints from the    *)
             (*      definition of op.                                       *)
             (****************************************************************)
-                op.argLevelConstraints
-                \union
-                
-                (****************************************************************)
+                    op.argLevelConstraints
+                    \union
+                    
+                    (****************************************************************)
             (* 2. arg[i].argLevelConstraints                                *)
             (*      Expression n inherits arg-level constraints from its    *)
             (*      arguments.                                              *)
             (****************************************************************)
-                (UNION {arg[i].argLevelConstraints: i \in 1..p})
-                \union
-                (****************************************************************)
+                    (UNION {arg[i].argLevelConstraints: i \in 1..p})
+                    \union
+                    (****************************************************************)
             (* 3. op.minMaxLevel                                            *)
             (*     If arg[i] is a declared operator, then it must be able   *)
             (*     to take a k-th argument of level op.minMaxLevel[i][k].   *)
             (****************************************************************)
-                (LET
-                        ALC(i) ==
-                        (*********************************************************)
+                    (LET
+                            ALC(i) ==
+                            (*********************************************************)
                    (* If arg[i] is the IdentifierNode of a declared         *)
                    (* operator opArg, then these are the arg-level          *)
                    (* constraints implied by op.minMaxLevel for opArg.      *)
                    (*********************************************************)
-                            {[param |-> arg[i].ref,
-                                idx |-> k,
-                                level |-> op.minMaxLevel[i][k]]:
-                                k \in 1..numOpArgs(i)}
-                    IN UNION {ALC(i): i \in declOpArgs})
-                \union
-                (****************************************************************)
+                                {[param |-> arg[i].ref,
+                                    idx |-> k,
+                                    level |-> op.minMaxLevel[i][k]]:
+                                    k \in 1..numOpArgs(i)}
+                        IN UNION {ALC(i): i \in declOpArgs})
+                    \union
+                    (****************************************************************)
             (* 4. op.opLevelCond                                            *)
             (*      If op.opLevelCond[i][j][k] is true and arg[i] is an     *)
             (*      Identifier node referring to the declared operator      *)
             (*      opArg, then opArg must be able to take a k-th argument  *)
             (*      of level arg[j].level.                                  *)
             (****************************************************************)
-                (LET ALC(i, j) ==
-                    (*********************************************************)
+                    (LET ALC(i, j) ==
+                        (*********************************************************)
                    (* If arg[i] is a declared operator, then this is the    *)
                    (* set of arg-level constraints implied for that         *)
                    (* operator by arg[j].level.                             *)
                    (*********************************************************)
-                        {[param |-> arg[i].ref,
-                            idx |-> k,
-                            level |-> arg[j].level]: k \in OpLevelCondIdx(i, j)}
-                    
-                    IN UNION {ALC(i, j): i \in declOpArgs, j \in 1..p})
-                \union
-                (****************************************************************)
+                            {[param |-> arg[i].ref,
+                                idx |-> k,
+                                level |-> arg[j].level]: k \in OpLevelCondIdx(i, j)}
+                        
+                        IN UNION {ALC(i, j): i \in declOpArgs, j \in 1..p})
+                    \union
+                    (****************************************************************)
             (* 5. op.argLevelParams                                         *)
             (*      If an arg-level parameter alp indicates that param[i]   *)
             (*      appears as the k-th argument of a declared operator     *)
@@ -1813,23 +1813,23 @@ DefinedOpApplNodeLevelCorrect(n) ==
             (*      that opArg must be able to take a k-th argument of      *)
             (*      level arg[i].level.                                     *)
             (****************************************************************)
-                (LET ALP(i) == {alp \in op.argLevelParams: alp.param = param[i]}
-                    (*********************************************************)
+                    (LET ALP(i) == {alp \in op.argLevelParams: alp.param = param[i]}
+                        (*********************************************************)
                    (* The subset of op.argLevelParams whose param field is  *)
                    (* the i-th formal parameter of op.                      *)
                    (*********************************************************)
-                        ALC(i) ==
-                        (*********************************************************)
+                            ALC(i) ==
+                            (*********************************************************)
                    (* The set of arg-level constraints implied by the       *)
                    (* elements of ALP(i).                                   *)
                    (*********************************************************)
-                            {[param |-> alp.param,
-                                idx |-> alp.idx,
-                                level |-> arg[i].level]: alp \in ALP(i)}
-                    IN UNION {ALC(i): i \in 1..p})
+                                {[param |-> alp.param,
+                                    idx |-> alp.idx,
+                                    level |-> arg[i].level]: alp \in ALP(i)}
+                        IN UNION {ALC(i): i \in 1..p})
     
         /\ n.argLevelParams =
-        (****************************************************************)
+            (****************************************************************)
             (* Arg-level parameters implied by the expression arise from    *)
             (* the following sources:                                       *)
             (****************************************************************)
@@ -1838,24 +1838,24 @@ DefinedOpApplNodeLevelCorrect(n) ==
             (*      The expression inherits all arg-level parameters from   *)
             (*      its arguments.                                          *)
             (****************************************************************)
-            (UNION {arg[i].argLevelParams: i \in 1..p})
-            \union
-            (****************************************************************)
+                (UNION {arg[i].argLevelParams: i \in 1..p})
+                \union
+                (****************************************************************)
             (* 2. Elements alp of op.argLevelParams with neither alp.op or  *)
             (*    alp.param a formal parameter of the definition of op.     *)
             (****************************************************************)
-            {alp \in op.argLevelParams:
-                \A i \in 1..p: (alp.op /= param[i]) /\ (alp.param /= param[i])}
-            \union
-            
-            (****************************************************************)
+                {alp \in op.argLevelParams:
+                    \A i \in 1..p: (alp.op /= param[i]) /\ (alp.param /= param[i])}
+                \union
+                
+                (****************************************************************)
             (* 3. Elements alp of op.argLevelParams with alp.op = param[i]. *)
             (*      If arg[i] is a declared operator opArg, then this       *)
             (*      implies an arg-level parameter asserting that alp.param *)
             (*      appears in argument alp.idx of opArg.                   *)
             (****************************************************************)
-            (LET ALP(i) == {alp \in op.argLevelParams: alp.op = param[i]}
-                (*********************************************************)
+                (LET ALP(i) == {alp \in op.argLevelParams: alp.op = param[i]}
+                    (*********************************************************)
                    (* The set of arg-level parameters alp of op with alp.op *)
                    (* = param[i].  (Note: we know that alp.param is not a   *)
                    (* formal parameter of op, because op.argLevelParams     *)
@@ -1863,15 +1863,15 @@ DefinedOpApplNodeLevelCorrect(n) ==
                    (* the op and param fields are formal parameters of the  *)
                    (* definition of op.)                                    *)
                    (*********************************************************)
-                    NLP(i) ==
-                    (*********************************************************)
+                        NLP(i) ==
+                        (*********************************************************)
                    (* The arg-level parameters of the expression implied by *)
                    (* the elements of ALP(i).                               *)
                    (*********************************************************)
-                        {[alp EXCEPT !.op = arg[i].ref]: alp \in ALP(i)}
-                IN UNION {NLP(i): i \in declOpArgs})
-            \union
-            (****************************************************************)
+                            {[alp EXCEPT !.op = arg[i].ref]: alp \in ALP(i)}
+                    IN UNION {NLP(i): i \in declOpArgs})
+                \union
+                (****************************************************************)
             (* 4. Elements alp of op.argLevelParams with alp.param =        *)
             (*    param[i].                                                 *)
             (*      This implies an arg-level parameter asserting that      *)
@@ -1879,24 +1879,24 @@ DefinedOpApplNodeLevelCorrect(n) ==
             (*      appears in argument alp.idx of an occurrence of         *)
             (*      alp.op.                                                 *)
             (****************************************************************)
-            (LET OLP(i) ==
-                (*********************************************************)
+                (LET OLP(i) ==
+                    (*********************************************************)
                    (* The set of all arg-level parameters whose param field *)
                    (* is param[i].                                          *)
                    (*********************************************************)
-                {alp \in op.argLevelParams: alp.param = param[i]}
-                    ALP(i) ==
-                    (*********************************************************)
+                    {alp \in op.argLevelParams: alp.param = param[i]}
+                        ALP(i) ==
+                        (*********************************************************)
                    (* The set of arg-level parameters obtained from an      *)
                    (* arg-level parameter alp in op.argLevelParams by       *)
                    (* replacing alp.param with an element of                *)
                    (* arg[i].levelParams.                                   *)
                    (*********************************************************)
-                        {[alp EXCEPT !.param = par]:
-                            alp \in OLP(i), par \in arg[i].levelParams}
-                IN UNION {ALP(i): i \in declOpArgs})
-            \union
-            (****************************************************************)
+                            {[alp EXCEPT !.param = par]:
+                                alp \in OLP(i), par \in arg[i].levelParams}
+                    IN UNION {ALP(i): i \in declOpArgs})
+                \union
+                (****************************************************************)
             (* 5. op.opLevelCond                                            *)
             (*      If op.opLevelCond[i][j][k] = TRUE and arg[i] is a       *)
             (*      declared operator opArg, then there are arg-level       *)
@@ -1904,15 +1904,15 @@ DefinedOpApplNodeLevelCorrect(n) ==
             (*      to the level of arg[j] appears in argument k of an      *)
             (*      occurrence of opArg.                                    *)
             (****************************************************************)
-            (LET ALP(i, j) ==
-                (*********************************************************)
+                (LET ALP(i, j) ==
+                    (*********************************************************)
                    (* If arg[i] is a declared operator, then this is the    *)
                    (* set of all all arg-level parameters implied by        *)
                    (* op.opLevelCond[i][j] and arg[j].levelParams.          *)
                    (*********************************************************)
-                    {[op |-> arg[i].ref, idx |-> k, param |-> par]:
-                        k \in OpLevelCondIdx(i, j), par \in arg[j].levelParams}
-                IN UNION {ALP(i, j): i \in declOpArgs, j \in 1..p})
+                        {[op |-> arg[i].ref, idx |-> k, param |-> par]:
+                            k \in OpLevelCondIdx(i, j), par \in arg[j].levelParams}
+                    IN UNION {ALP(i, j): i \in declOpArgs, j \in 1..p})
 
 OpApplNodeLevelCorrect(n) ==
     IF n.operator \in OpDeclNodeId THEN DeclaredOpApplNodeLevelCorrect(n)
@@ -1940,7 +1940,7 @@ LetInNodeLevelCorrect(n) ==
     IN
         /\ n.level = exp.level
         /\ n.levelParams =
-        exp.levelParams
+            exp.levelParams
         /\ n.levelConstraints =
             exp.levelConstraints \union
             UNION {Node[opid].levelConstraints: opid \in letIds}
@@ -1970,28 +1970,28 @@ IdentifierNodeLevelCorrect(n) ==
         (* The level is the level of the symbol's node.                     *)
         (********************************************************************)
     /\ IF n.ref \in OpDeclNodeId \union BoundSymbolNodeId
-    THEN (***************************************************************)
+        THEN (***************************************************************)
              (* The symbol is a declared operator or a bound symbol.  In    *)
              (* this case, all the constraints are empty except for a       *)
              (* ConstantDeclNode, in which case the set of level parameters *)
              (* consists of the symbol itself.                              *)
              (***************************************************************)
-        /\ n.levelParams = IF n.ref \in ConstantDeclNodeId
-        THEN {n.ref}
-        ELSE {}
-        /\ n.levelConstraints = {}
-        /\ n.argLevelConstraints = {}
-        /\ n.argLevelParams = {}
-    
-    ELSE (***************************************************************)
+            /\ n.levelParams = IF n.ref \in ConstantDeclNodeId
+                THEN {n.ref}
+                ELSE {}
+            /\ n.levelConstraints = {}
+            /\ n.argLevelConstraints = {}
+            /\ n.argLevelParams = {}
+        
+        ELSE (***************************************************************)
              (* The symbol is a defined operator (appearing as an argument  *)
              (* to a higher-order operator).  Its constraints are the       *)
              (* constraints of the symbol's OpDefNode.                      *)
              (***************************************************************)
-        /\ n.levelParams = Node[n.ref].levelParams
-        /\ n.levelConstraints = Node[n.ref].levelConstraints
-        /\ n.argLevelConstraints = Node[n.ref].argLevelConstraints
-        /\ n.argLevelParams = Node[n.ref].argLevelParams
+            /\ n.levelParams = Node[n.ref].levelParams
+            /\ n.levelConstraints = Node[n.ref].levelConstraints
+            /\ n.argLevelConstraints = Node[n.ref].argLevelConstraints
+            /\ n.argLevelParams = Node[n.ref].argLevelParams
 
 LevelCorrect ==
     (*************************************************************************)

--- a/libtlafmt/tests/snapshots/format__corpus@MCRealTime.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@MCRealTime.tla.snap
@@ -24,8 +24,8 @@ RTNext(v) ==
 TimerInit(t) == t = 0
 TimerNext(t, A, v, D, E) ==
     /\ t' = IF <<A>>_v \/ ~(ENABLED <<A>>_v) ' \* [ ]_<<now, v, t>> removed
-    THEN 0
-    ELSE t + (now' - now)
+        THEN 0
+        ELSE t + (now' - now)
 
     /\ t' <= E \* MaxTime constraint
 

--- a/libtlafmt/tests/snapshots/format__corpus@MissionariesAndCannibals.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@MissionariesAndCannibals.tla.snap
@@ -181,7 +181,7 @@ Move(S, b) ==
         /\ who_is_on_bank' =
             [i \in {"E", "W"} |-> IF i = b THEN newThisBank
                 ELSE newOtherBank]
-        
+            
 (***************************************************************************)
 (* The next-state formula Next describes all steps s -> t that represent a *)
 (* safe move of a set S of people across the river starting from           *)

--- a/libtlafmt/tests/snapshots/format__corpus@MultiPaxos.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@MultiPaxos.tla.snap
@@ -469,140 +469,140 @@ Init == (* Global variables *)
 rloop(self) ==
     /\ pc[self] = "rloop"
     /\ IF ~terminated
-    THEN
-        /\
-            \/
-                /\ node[self].leader /= self
-                /\ \E b \in Ballots:
-                    /\
-                        /\ b > node[self].balMaxKnown
-                        /\ ~\E m \in msgs: (m.type = "Prepare") /\ (m.bal = b)
-                    /\ node' = [node EXCEPT ![self].leader = self,
-                        ![self].balPrepared = 0,
-                        ![self].balMaxKnown = b,
-                        ![self].insts = [s \in Slots |->
-                            [node[self].insts[s]
-                            EXCEPT !.status = IF @ = "Accepting"
-                                THEN "Preparing"
-                                ELSE @]]]
-                    /\ msgs' = (msgs \union ({PrepareMsg(self, b),
-                                PrepareReplyMsg(self, b, VotesByNode(node' [self]))}))
-                /\ UNCHANGED << pending, observed >>
-            \/
-                /\ \E m \in msgs:
+        THEN
+            /\
+                \/
+                    /\ node[self].leader /= self
+                    /\ \E b \in Ballots:
                         /\
-                            /\ m.type = "Prepare"
-                            /\ m.bal > node[self].balMaxKnown
-                        /\ node' = [node EXCEPT ![self].leader = m.src,
-                            ![self].balMaxKnown = m.bal,
+                            /\ b > node[self].balMaxKnown
+                            /\ ~\E m \in msgs: (m.type = "Prepare") /\ (m.bal = b)
+                        /\ node' = [node EXCEPT ![self].leader = self,
+                            ![self].balPrepared = 0,
+                            ![self].balMaxKnown = b,
                             ![self].insts = [s \in Slots |->
                                 [node[self].insts[s]
                                 EXCEPT !.status = IF @ = "Accepting"
                                     THEN "Preparing"
                                     ELSE @]]]
-                        /\ msgs' = (msgs \union ({PrepareReplyMsg(self, m.bal, VotesByNode(node' [self]))}))
-                /\ UNCHANGED << pending, observed >>
-            \/
-                /\
-                    /\ node[self].leader = self
-                    /\ node[self].balPrepared = 0
-                /\ LET prs == {m \in msgs:
-                        /\ m.type = "PrepareReply"
-                        /\ m.bal = node[self].balMaxKnown} IN
-                    /\ Cardinality(prs) >= MajorityNum
-                    /\ node' = [node EXCEPT ![self].balPrepared = node[self].balMaxKnown,
-                        ![self].insts = [s \in Slots |->
-                            [node[self].insts[s]
-                            EXCEPT !.status = IF
-                                        \/ @ = "Preparing"
-                                        \/
-                                            /\ @ = "Empty"
-                                            /\ PeakVotedCmd(prs, s) /= "nil"
-                                    THEN "Accepting"
-                                    ELSE @,
-                                !.cmd = PeakVotedCmd(prs, s)]]]
-                    /\ msgs' = (msgs \union ({AcceptMsg(self, node' [self].balPrepared, s, node' [self].insts[s].cmd):
-                                s \in {s \in Slots: node' [self].insts[s].status = "Accepting"}}))
-                /\ UNCHANGED << pending, observed >>
-            \/
-                /\
-                    /\ node[self].leader = self
-                    /\ node[self].balPrepared = node[self].balMaxKnown
-                    /\ \E s \in Slots: node[self].insts[s].status = "Empty"
-                    /\ Len(UnseenPending(node[self].insts)) > 0
-                /\ LET s == FirstEmptySlot(node[self].insts) IN
-                    LET c == Head(UnseenPending(node[self].insts)) IN
-                        /\ node' = [node EXCEPT ![self].insts[s].status = "Accepting",
-                            ![self].insts[s].cmd = c,
-                            ![self].insts[s].voted.bal = node[self].balPrepared,
-                            ![self].insts[s].voted.cmd = c]
-                        /\ msgs' = (msgs \union ({AcceptMsg(self, node' [self].balPrepared, s, c),
-                            AcceptReplyMsg(self, node' [self].balPrepared, s)}))
-                        /\ IF (ReqEvent(c)) \notin Range(observed)
-                        THEN
-                            /\ observed' = Append(observed, (ReqEvent(c)))
-                        ELSE
-                            /\ TRUE
-                            /\ UNCHANGED observed
-                /\ UNCHANGED pending
-            \/
-                /\ \E m \in msgs:
-                    /\
-                        /\ m.type = "Accept"
-                        /\ m.bal >= node[self].balMaxKnown
-                        /\ m.bal > node[self].insts[m.slot].voted.bal
-                    /\ node' = [node EXCEPT ![self].leader = m.src,
-                        ![self].balMaxKnown = m.bal,
-                        ![self].insts[m.slot].status = "Accepting",
-                        ![self].insts[m.slot].cmd = m.cmd,
-                        ![self].insts[m.slot].voted.bal = m.bal,
-                        ![self].insts[m.slot].voted.cmd = m.cmd]
-                    /\ msgs' = (msgs \union ({AcceptReplyMsg(self, m.bal, m.slot)}))
-                /\ UNCHANGED << pending, observed >>
-            \/
-                /\
-                    /\ node[self].leader = self
-                    /\ node[self].balPrepared = node[self].balMaxKnown
-                    /\ node[self].commitUpTo < NumCommands
-                    /\ node[self].insts[node[self].commitUpTo + 1].status = "Accepting"
-                /\ LET s == node[self].commitUpTo + 1 IN
-                    LET c == node[self].insts[s].cmd IN
-                        LET v == node[self].kvalue IN
-                            LET ars == {m \in msgs:
-                                    /\ m.type = "AcceptReply"
-                                    /\ m.slot = s
-                                    /\ m.bal = node[self].balPrepared} IN
-                                /\ Cardinality(ars) >= MajorityNum
-                                /\ node' = [node EXCEPT ![self].insts[s].status = "Committed",
-                                    ![self].commitUpTo = s,
-                                    ![self].kvalue = IF c \in Writes THEN c ELSE @]
-                                /\ IF (AckEvent(c, v)) \notin Range(observed)
-                                THEN
-                                    /\ observed' = Append(observed, (AckEvent(c, v)))
-                                ELSE
-                                    /\ TRUE
-                                    /\ UNCHANGED observed
-                                /\ pending' = RemovePending(c)
-                                /\ msgs' = (msgs \union ({CommitNoticeMsg(s)}))
-            \/
-                /\
-                    /\ node[self].leader /= self
-                    /\ node[self].commitUpTo < NumCommands
-                    /\ node[self].insts[node[self].commitUpTo + 1].status = "Accepting"
-                /\ LET s == node[self].commitUpTo + 1 IN
-                    LET c == node[self].insts[s].cmd IN
-                        \E m \in msgs:
+                        /\ msgs' = (msgs \union ({PrepareMsg(self, b),
+                                    PrepareReplyMsg(self, b, VotesByNode(node' [self]))}))
+                    /\ UNCHANGED << pending, observed >>
+                \/
+                        /\ \E m \in msgs:
                             /\
-                                /\ m.type = "CommitNotice"
-                                /\ m.upto = s
-                            /\ node' = [node EXCEPT ![self].insts[s].status = "Committed",
-                                ![self].commitUpTo = s,
-                                ![self].kvalue = IF c \in Writes THEN c ELSE @]
-                /\ UNCHANGED << msgs, pending, observed >>
-        /\ pc' = [pc EXCEPT ![self] = "rloop"]
-    ELSE
-        /\ pc' = [pc EXCEPT ![self] = "Done"]
-        /\ UNCHANGED << msgs, node, pending, observed >>
+                                /\ m.type = "Prepare"
+                                /\ m.bal > node[self].balMaxKnown
+                            /\ node' = [node EXCEPT ![self].leader = m.src,
+                                ![self].balMaxKnown = m.bal,
+                                ![self].insts = [s \in Slots |->
+                                    [node[self].insts[s]
+                                    EXCEPT !.status = IF @ = "Accepting"
+                                        THEN "Preparing"
+                                        ELSE @]]]
+                            /\ msgs' = (msgs \union ({PrepareReplyMsg(self, m.bal, VotesByNode(node' [self]))}))
+                        /\ UNCHANGED << pending, observed >>
+                \/
+                        /\
+                            /\ node[self].leader = self
+                            /\ node[self].balPrepared = 0
+                        /\ LET prs == {m \in msgs:
+                                /\ m.type = "PrepareReply"
+                                /\ m.bal = node[self].balMaxKnown} IN
+                            /\ Cardinality(prs) >= MajorityNum
+                            /\ node' = [node EXCEPT ![self].balPrepared = node[self].balMaxKnown,
+                                ![self].insts = [s \in Slots |->
+                                    [node[self].insts[s]
+                                    EXCEPT !.status = IF
+                                                \/ @ = "Preparing"
+                                                \/
+                                                    /\ @ = "Empty"
+                                                    /\ PeakVotedCmd(prs, s) /= "nil"
+                                            THEN "Accepting"
+                                            ELSE @,
+                                        !.cmd = PeakVotedCmd(prs, s)]]]
+                            /\ msgs' = (msgs \union ({AcceptMsg(self, node' [self].balPrepared, s, node' [self].insts[s].cmd):
+                                        s \in {s \in Slots: node' [self].insts[s].status = "Accepting"}}))
+                        /\ UNCHANGED << pending, observed >>
+                \/
+                        /\
+                                /\ node[self].leader = self
+                                /\ node[self].balPrepared = node[self].balMaxKnown
+                                /\ \E s \in Slots: node[self].insts[s].status = "Empty"
+                                /\ Len(UnseenPending(node[self].insts)) > 0
+                        /\ LET s == FirstEmptySlot(node[self].insts) IN
+                                LET c == Head(UnseenPending(node[self].insts)) IN
+                                    /\ node' = [node EXCEPT ![self].insts[s].status = "Accepting",
+                                        ![self].insts[s].cmd = c,
+                                        ![self].insts[s].voted.bal = node[self].balPrepared,
+                                        ![self].insts[s].voted.cmd = c]
+                                    /\ msgs' = (msgs \union ({AcceptMsg(self, node' [self].balPrepared, s, c),
+                                        AcceptReplyMsg(self, node' [self].balPrepared, s)}))
+                                    /\ IF (ReqEvent(c)) \notin Range(observed)
+                                        THEN
+                                            /\ observed' = Append(observed, (ReqEvent(c)))
+                                        ELSE
+                                            /\ TRUE
+                                            /\ UNCHANGED observed
+                        /\ UNCHANGED pending
+                \/
+                        /\ \E m \in msgs:
+                                    /\
+                                        /\ m.type = "Accept"
+                                        /\ m.bal >= node[self].balMaxKnown
+                                        /\ m.bal > node[self].insts[m.slot].voted.bal
+                                    /\ node' = [node EXCEPT ![self].leader = m.src,
+                                        ![self].balMaxKnown = m.bal,
+                                        ![self].insts[m.slot].status = "Accepting",
+                                        ![self].insts[m.slot].cmd = m.cmd,
+                                        ![self].insts[m.slot].voted.bal = m.bal,
+                                        ![self].insts[m.slot].voted.cmd = m.cmd]
+                                    /\ msgs' = (msgs \union ({AcceptReplyMsg(self, m.bal, m.slot)}))
+                        /\ UNCHANGED << pending, observed >>
+                \/
+                        /\
+                            /\ node[self].leader = self
+                            /\ node[self].balPrepared = node[self].balMaxKnown
+                            /\ node[self].commitUpTo < NumCommands
+                            /\ node[self].insts[node[self].commitUpTo + 1].status = "Accepting"
+                        /\ LET s == node[self].commitUpTo + 1 IN
+                            LET c == node[self].insts[s].cmd IN
+                                LET v == node[self].kvalue IN
+                                    LET ars == {m \in msgs:
+                                            /\ m.type = "AcceptReply"
+                                            /\ m.slot = s
+                                            /\ m.bal = node[self].balPrepared} IN
+                                        /\ Cardinality(ars) >= MajorityNum
+                                        /\ node' = [node EXCEPT ![self].insts[s].status = "Committed",
+                                            ![self].commitUpTo = s,
+                                            ![self].kvalue = IF c \in Writes THEN c ELSE @]
+                                        /\ IF (AckEvent(c, v)) \notin Range(observed)
+                                            THEN
+                                                /\ observed' = Append(observed, (AckEvent(c, v)))
+                                            ELSE
+                                                /\ TRUE
+                                                /\ UNCHANGED observed
+                                        /\ pending' = RemovePending(c)
+                                        /\ msgs' = (msgs \union ({CommitNoticeMsg(s)}))
+                \/
+                        /\
+                                /\ node[self].leader /= self
+                                /\ node[self].commitUpTo < NumCommands
+                                /\ node[self].insts[node[self].commitUpTo + 1].status = "Accepting"
+                        /\ LET s == node[self].commitUpTo + 1 IN
+                                LET c == node[self].insts[s].cmd IN
+                                    \E m \in msgs:
+                                        /\
+                                            /\ m.type = "CommitNotice"
+                                            /\ m.upto = s
+                                        /\ node' = [node EXCEPT ![self].insts[s].status = "Committed",
+                                            ![self].commitUpTo = s,
+                                            ![self].kvalue = IF c \in Writes THEN c ELSE @]
+                        /\ UNCHANGED << msgs, pending, observed >>
+            /\ pc' = [pc EXCEPT ![self] = "rloop"]
+        ELSE
+            /\ pc' = [pc EXCEPT ![self] = "Done"]
+            /\ UNCHANGED << msgs, node, pending, observed >>
 
 Replica(self) == rloop(self)
 

--- a/libtlafmt/tests/snapshots/format__corpus@PConProof.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@PConProof.tla.snap
@@ -372,11 +372,11 @@ leader(self) ==
                 /\ \A v \in S: \E Q \in Quorum: ShowsSafeAt(Q, self, v)
                 /\ msgs' = (msgs \union ({[type |-> "1c", bal |-> self, val |-> v]: v \in S}))
         \/
-            /\ \E v \in Value:
-                /\
-                    /\ sentMsgs("2a", self) = {}
-                    /\ [type |-> "1c", bal |-> self, val |-> v] \in msgs
-                /\ msgs' = (msgs \union {([type |-> "2a", bal |-> self, val |-> v])})
+                /\ \E v \in Value:
+                    /\
+                        /\ sentMsgs("2a", self) = {}
+                        /\ [type |-> "1c", bal |-> self, val |-> v] \in msgs
+                    /\ msgs' = (msgs \union {([type |-> "2a", bal |-> self, val |-> v])})
     /\ UNCHANGED << maxBal, maxVBal, maxVVal >>
 
 Next == (\E self \in Acceptor: acceptor(self))
@@ -434,7 +434,7 @@ TLANext ==
             \/ Phase1a(self)
             \/ \E S \in SUBSET Value: Phase1c(self, S)
             \/ \E v \in Value: Phase2a(self, v)
-        
+            
 (***************************************************************************)
 (* The following theorem specifies the relation between the next-state     *)
 (* relation Next obtained by translating the PlusCal code and the          *)

--- a/libtlafmt/tests/snapshots/format__corpus@ParReach.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@ParReach.tla.snap
@@ -113,40 +113,40 @@ Init == (* Global variables *)
 a(self) ==
     /\ pc[self] = "a"
     /\ IF vroot /= {}
-    THEN
-        /\ \E v \in vroot:
-            u' = [u EXCEPT ![self] = v]
-        /\ pc' = [pc EXCEPT ![self] = "b"]
-    ELSE
-        /\ pc' = [pc EXCEPT ![self] = "Done"]
-        /\ u' = u
+        THEN
+            /\ \E v \in vroot:
+                u' = [u EXCEPT ![self] = v]
+            /\ pc' = [pc EXCEPT ![self] = "b"]
+        ELSE
+            /\ pc' = [pc EXCEPT ![self] = "Done"]
+            /\ u' = u
     /\ UNCHANGED << marked, vroot, toVroot >>
 
 b(self) ==
     /\ pc[self] = "b"
     /\ IF u[self] \notin marked
-    THEN
-        /\ marked' = (marked \union {u[self]})
-        /\ toVroot' = [toVroot EXCEPT ![self] = Succ[u[self]]]
-        /\ pc' = [pc EXCEPT ![self] = "c"]
-        /\ vroot' = vroot
-    ELSE
-        /\ vroot' = vroot \ {u[self]}
-        /\ pc' = [pc EXCEPT ![self] = "a"]
-        /\ UNCHANGED << marked, toVroot >>
+        THEN
+            /\ marked' = (marked \union {u[self]})
+            /\ toVroot' = [toVroot EXCEPT ![self] = Succ[u[self]]]
+            /\ pc' = [pc EXCEPT ![self] = "c"]
+            /\ vroot' = vroot
+        ELSE
+            /\ vroot' = vroot \ {u[self]}
+            /\ pc' = [pc EXCEPT ![self] = "a"]
+            /\ UNCHANGED << marked, toVroot >>
     /\ u' = u
 
 c(self) ==
     /\ pc[self] = "c"
     /\ IF toVroot[self] /= {}
-    THEN
-        /\ \E w \in toVroot[self]:
-            /\ vroot' = (vroot \union {w})
-            /\ toVroot' = [toVroot EXCEPT ![self] = toVroot[self] \ {w}]
-        /\ pc' = [pc EXCEPT ![self] = "c"]
-    ELSE
-        /\ pc' = [pc EXCEPT ![self] = "a"]
-        /\ UNCHANGED << vroot, toVroot >>
+        THEN
+            /\ \E w \in toVroot[self]:
+                /\ vroot' = (vroot \union {w})
+                /\ toVroot' = [toVroot EXCEPT ![self] = toVroot[self] \ {w}]
+            /\ pc' = [pc EXCEPT ![self] = "c"]
+        ELSE
+            /\ pc' = [pc EXCEPT ![self] = "a"]
+            /\ UNCHANGED << vroot, toVroot >>
     /\ UNCHANGED << marked, u >>
 
 p(self) == a(self) \/ b(self) \/ c(self)
@@ -195,7 +195,7 @@ Inv ==
     /\ \A q \in Procs:
         /\ (pc[q] \in {"a", "b", "Done"}) => (toVroot[q] = {})
         /\ (pc[q] = "b") => (u[q] \in vroot \union marked)
-        
+            
 (***************************************************************************)
 (* To define a refinement mapping from states of the parallel algorithm to *)
 (* states of Misra's algorithm, we must define the expressions in this     *)

--- a/libtlafmt/tests/snapshots/format__corpus@Paxos.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Paxos.tla.snap
@@ -104,7 +104,7 @@ PaxosPromise ==
             acceptor |-> a,
             maxVBallot |-> maxVBallot[a],
             maxValue |-> maxValue[a]])
-        
+            
 (*
     Phase 2a:
 
@@ -133,7 +133,7 @@ PaxosAccept ==
                 /\ SendMessage([type |-> "P2a",
                     ballot |-> b,
                     value |-> v])
-                
+                        
 (*
     Phase 2b:
 
@@ -158,7 +158,7 @@ PaxosAccepted ==
             ballot |-> m.ballot,
             acceptor |-> a,
             value |-> m.value])
-        
+            
 (*
     Consensus is achieved when a majority of acceptors accept the same ballot number (rather than the same value).
     Because each ballot is unique to a proposer and only one value may be proposed per ballot, all acceptors
@@ -210,7 +210,7 @@ PaxosNontriviality ==
     /\ \A m \in p1bMessages:
         /\ m.maxValue \in Values \/ 0 = m.maxVBallot
         /\ m.maxValue = none \/ 0 < m.maxVBallot
-        
+            
 \* Consistency safety property: At most 1 value can be learnt.
 PaxosConsistency == [][decision = none]_<< decision >>
 

--- a/libtlafmt/tests/snapshots/format__corpus@Prisoners.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Prisoners.tla.snap
@@ -127,13 +127,13 @@ NonCounterStep(i) ==
   (* flips switch B.                                                       *)
   (*************************************************************************)
     /\ IF (~switchAUp) /\ (timesSwitched[i] < 2)
-    THEN
-        /\ switchAUp' = TRUE
-        /\ timesSwitched' = [timesSwitched EXCEPT ![i] = @ + 1]
-        /\ UNCHANGED switchBUp
-    ELSE
-        /\ switchBUp' = ~switchBUp
-        /\ UNCHANGED << switchAUp, timesSwitched >>
+        THEN
+            /\ switchAUp' = TRUE
+            /\ timesSwitched' = [timesSwitched EXCEPT ![i] = @ + 1]
+            /\ UNCHANGED switchBUp
+        ELSE
+            /\ switchBUp' = ~switchBUp
+            /\ UNCHANGED << switchAUp, timesSwitched >>
     /\ UNCHANGED count
 
 CounterStep ==
@@ -142,13 +142,13 @@ CounterStep ==
   (* her) count.  Otherwise, (s)he flips switch B.                         *)
   (*************************************************************************)
     /\ IF switchAUp
-    THEN
-        /\ switchAUp' = FALSE
-        /\ UNCHANGED switchBUp
-        /\ count' = count + 1
-    ELSE
-        /\ switchBUp' = ~switchBUp
-        /\ UNCHANGED << switchAUp, count >>
+        THEN
+            /\ switchAUp' = FALSE
+            /\ UNCHANGED switchBUp
+            /\ count' = count + 1
+        ELSE
+            /\ switchBUp' = ~switchBUp
+            /\ UNCHANGED << switchAUp, count >>
     /\ UNCHANGED timesSwitched
 
 Next ==

--- a/libtlafmt/tests/snapshots/format__corpus@QueensPluscal.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@QueensPluscal.tla.snap
@@ -83,24 +83,24 @@ Init == (* Global variables *)
 nxtQ ==
     /\ pc = "nxtQ"
     /\ IF todo /= {}
-    THEN
-        /\ \E queens \in todo:
-            LET nxtQ == Len(queens) + 1 IN
-                LET cols == {c \in 1..N: ~\E i \in 1..Len(queens):
-                            Attacks(Append(queens, c), i, nxtQ)} IN
-                    LET exts == {Append(queens, c): c \in cols} IN
-                    IF (nxtQ = N)
-                    THEN
-                        /\ todo' = todo \ {queens}
-                        /\ sols' = (sols \union exts)
-                    ELSE
-                        /\ todo' = ((todo \ {queens}) \union exts)
-                        /\ sols' = sols
-        /\ pc' = "nxtQ"
-    ELSE
-        /\ pc' = "Done"
-        /\ UNCHANGED << todo, sols >>
-    
+        THEN
+            /\ \E queens \in todo:
+                LET nxtQ == Len(queens) + 1 IN
+                    LET cols == {c \in 1..N: ~\E i \in 1..Len(queens):
+                                Attacks(Append(queens, c), i, nxtQ)} IN
+                        LET exts == {Append(queens, c): c \in cols} IN
+                        IF (nxtQ = N)
+                        THEN
+                            /\ todo' = todo \ {queens}
+                            /\ sols' = (sols \union exts)
+                        ELSE
+                            /\ todo' = ((todo \ {queens}) \union exts)
+                            /\ sols' = sols
+            /\ pc' = "nxtQ"
+        ELSE
+            /\ pc' = "Done"
+            /\ UNCHANGED << todo, sols >>
+        
 (* Allow infinite stuttering to prevent deadlock on termination. *)
 Terminating == pc = "Done" /\ UNCHANGED vars
 

--- a/libtlafmt/tests/snapshots/format__corpus@Quicksort.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Quicksort.tla.snap
@@ -143,23 +143,23 @@ Init == (* Global variables *)
 a ==
     /\ pc = "a"
     /\ IF U /= {}
-    THEN
-        /\ \E I \in U:
-            IF Cardinality(I) = 1
-            THEN
-                /\ U' = U \ {I}
-                /\ seq' = seq
-            ELSE
-                /\ \E p \in Min(I)..(Max(I) - 1):
-                    LET I1 == Min(I)..p IN
-                        LET I2 == (p + 1)..Max(I) IN
-                            \E newseq \in Partitions(I, p, seq):
-                                /\ seq' = newseq
-                                /\ U' = ((U \ {I}) \union {I1, I2})
-        /\ pc' = "a"
-    ELSE
-        /\ pc' = "Done"
-        /\ UNCHANGED << seq, U >>
+        THEN
+            /\ \E I \in U:
+                IF Cardinality(I) = 1
+                THEN
+                    /\ U' = U \ {I}
+                    /\ seq' = seq
+                ELSE
+                    /\ \E p \in Min(I)..(Max(I) - 1):
+                        LET I1 == Min(I)..p IN
+                            LET I2 == (p + 1)..Max(I) IN
+                                \E newseq \in Partitions(I, p, seq):
+                                    /\ seq' = newseq
+                                    /\ U' = ((U \ {I}) \union {I1, I2})
+            /\ pc' = "a"
+        ELSE
+            /\ pc' = "Done"
+            /\ UNCHANGED << seq, U >>
     /\ seq0' = seq0
 
 (* Allow infinite stuttering to prevent deadlock on termination. *)

--- a/libtlafmt/tests/snapshots/format__corpus@Reachable.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Reachable.tla.snap
@@ -96,20 +96,20 @@ Init == (* Global variables *)
 a ==
     /\ pc = "a"
     /\ IF vroot /= {}
-    THEN
-        /\ \E v \in vroot:
-            IF v \notin marked
-            THEN
-                /\ marked' = (marked \union {v})
-                /\ vroot' = (vroot \union Succ[v])
-            ELSE
-                /\ vroot' = vroot \ {v}
-                /\ UNCHANGED marked
-        /\ pc' = "a"
-    ELSE
-        /\ pc' = "Done"
-        /\ UNCHANGED << marked, vroot >>
-    
+        THEN
+            /\ \E v \in vroot:
+                IF v \notin marked
+                THEN
+                    /\ marked' = (marked \union {v})
+                    /\ vroot' = (vroot \union Succ[v])
+                ELSE
+                    /\ vroot' = vroot \ {v}
+                    /\ UNCHANGED marked
+            /\ pc' = "a"
+        ELSE
+            /\ pc' = "Done"
+            /\ UNCHANGED << marked, vroot >>
+        
 (* Allow infinite stuttering to prevent deadlock on termination. *)
 Terminating == pc = "Done" /\ UNCHANGED vars
 

--- a/libtlafmt/tests/snapshots/format__corpus@SPA_Attack.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@SPA_Attack.tla.snap
@@ -368,26 +368,26 @@ UsrCommitSpaAuth ==
     /\ uState' = "Auth_End"
     /\ uTstamp' = uTstamp + 1 \* uTstamp increases each session for anti-replay. 
     /\ AuthChannel' = Append(AuthChannel,
-        [MsgID |-> "SPA_AUTH",
-            sIP |-> uIP,
-            sPort |-> SelLocalPort(uTstamp, USER_BASEPORT),
-            dIP |-> uSDPSvrInfo.IP,
-            dPort |-> uSDPSvrInfo.Port,
-            ClientID |-> uID,
-            Tstamp |-> uTstamp,
-            SvrIP |-> Encrypt(uSvrInfo.IP, Key),
-            SvrPort |-> Encrypt(uSvrInfo.Port, Key),
-            HMAC |-> CalcHMAC(uIP, uID, uTstamp, Encrypt(uSvrInfo.IP, Key),
-                Encrypt(uSvrInfo.Port, Key), Key),
-            Type |-> "User"]
-    )
-    /\ uAuthSession' = uAuthSession \union {Head(AuthChannel')} \* Auth session is recorded in Log
-    /\ UNCHANGED << uIP, uID, Key, uSDPSvrInfo, uSvrInfo, uTCPLinkSet >>
-    /\ UNCHANGED sdpsvr_vars
-    /\ UNCHANGED fw_vars
-    /\ UNCHANGED attacker_vars
-    /\ UNCHANGED server_vars
-    /\ UNCHANGED << uChannel, FwCtlChannel, FwDataChannel, aChannel, sChannel >>
+                [MsgID |-> "SPA_AUTH",
+                    sIP |-> uIP,
+                    sPort |-> SelLocalPort(uTstamp, USER_BASEPORT),
+                    dIP |-> uSDPSvrInfo.IP,
+                    dPort |-> uSDPSvrInfo.Port,
+                    ClientID |-> uID,
+                    Tstamp |-> uTstamp,
+                    SvrIP |-> Encrypt(uSvrInfo.IP, Key),
+                    SvrPort |-> Encrypt(uSvrInfo.Port, Key),
+                    HMAC |-> CalcHMAC(uIP, uID, uTstamp, Encrypt(uSvrInfo.IP, Key),
+                        Encrypt(uSvrInfo.Port, Key), Key),
+                    Type |-> "User"]
+        )
+        /\ uAuthSession' = uAuthSession \union {Head(AuthChannel')} \* Auth session is recorded in Log
+        /\ UNCHANGED << uIP, uID, Key, uSDPSvrInfo, uSvrInfo, uTCPLinkSet >>
+        /\ UNCHANGED sdpsvr_vars
+        /\ UNCHANGED fw_vars
+        /\ UNCHANGED attacker_vars
+        /\ UNCHANGED server_vars
+        /\ UNCHANGED << uChannel, FwCtlChannel, FwDataChannel, aChannel, sChannel >>
     \*/\ UNCHANGED <<vars \ (uState,uTstamp,AuthChannel,uAuthSession) >>
 
 \* Action 2: UsrConnectSvr
@@ -544,42 +544,42 @@ SDPSvrProcSpaAuth ==
     /\ Head(AuthChannel).dIP = SDPSvrInfo.IP
     /\ Head(AuthChannel).dPort = SDPSvrInfo.Port
     /\ IF FindAntiReplay(Head(AuthChannel), SDPSucSession) = TRUE \* case 1: the packet is a replay message 
-    THEN
-        /\ SDPSvrAntiReplayAtk \*drop packets and record exception into log
-        /\ UNCHANGED user_vars
-        /\ UNCHANGED << SDPSvrState, SDPSucSession, Account, SDPSvrInfo, SpoofCount, SpoofSession >>
-        /\ UNCHANGED fw_vars
-        /\ UNCHANGED attacker_vars
-        /\ UNCHANGED server_vars
-        /\ UNCHANGED << uChannel, FwCtlChannel, FwDataChannel, aChannel, sChannel >>
-    ELSE
-        /\ IF SpaProcAuth(Head(AuthChannel), Account) = FALSE \* case 2: it is a spoof message or from unknown user
         THEN
-            /\ SDPSvrAntiSpoof \*drop packets and record exception into log
+            /\ SDPSvrAntiReplayAtk \*drop packets and record exception into log
             /\ UNCHANGED user_vars
-            /\ UNCHANGED << SDPSvrState, SDPSucSession, Account, SDPSvrInfo, ReplayCount, ReplaySession >>
+            /\ UNCHANGED << SDPSvrState, SDPSucSession, Account, SDPSvrInfo, SpoofCount, SpoofSession >>
             /\ UNCHANGED fw_vars
             /\ UNCHANGED attacker_vars
             /\ UNCHANGED server_vars
             /\ UNCHANGED << uChannel, FwCtlChannel, FwDataChannel, aChannel, sChannel >>
-        ELSE \*case 3: Authenticated successfully, then send instruction to FW to allow data access towards target server.
-            /\ SDPSvrCfgFw([sIP |-> Head(AuthChannel).sIP,
-                    sPort |-> MATCH_ANY, \* this Acl Rule is 3 tuple, for data access source port is undetermined now.
-                    dIP |-> DeCrypt(Head(AuthChannel).SvrIP, GetKey(Head(AuthChannel).ClientID, Account)),
-                    dPort |-> DeCrypt(Head(AuthChannel).SvrPort, GetKey(Head(AuthChannel).ClientID, Account)),
-                    protocol |-> "TCP",
-                    action |-> "Accept"],
-                "Add" \* The instruction code is to Add a new rule.
-            )
-            /\ SDPSucSession' = SDPSucSession \union {Head(AuthChannel)} \*record in log
-            /\ AuthChannel' = Tail(AuthChannel)
-            /\ UNCHANGED user_vars
-            /\ UNCHANGED << SDPSvrState, Account, SDPSvrInfo, ReplayCount, SpoofCount, ReplaySession, SpoofSession >>
-            /\ UNCHANGED fw_vars
-            /\ UNCHANGED attacker_vars
-            /\ UNCHANGED server_vars
-            /\ UNCHANGED << uChannel, FwDataChannel, aChannel, sChannel >>
-        
+        ELSE
+            /\ IF SpaProcAuth(Head(AuthChannel), Account) = FALSE \* case 2: it is a spoof message or from unknown user
+                THEN
+                    /\ SDPSvrAntiSpoof \*drop packets and record exception into log
+                    /\ UNCHANGED user_vars
+                    /\ UNCHANGED << SDPSvrState, SDPSucSession, Account, SDPSvrInfo, ReplayCount, ReplaySession >>
+                    /\ UNCHANGED fw_vars
+                    /\ UNCHANGED attacker_vars
+                    /\ UNCHANGED server_vars
+                    /\ UNCHANGED << uChannel, FwCtlChannel, FwDataChannel, aChannel, sChannel >>
+                ELSE \*case 3: Authenticated successfully, then send instruction to FW to allow data access towards target server.
+                    /\ SDPSvrCfgFw([sIP |-> Head(AuthChannel).sIP,
+                                sPort |-> MATCH_ANY, \* this Acl Rule is 3 tuple, for data access source port is undetermined now.
+                                dIP |-> DeCrypt(Head(AuthChannel).SvrIP, GetKey(Head(AuthChannel).ClientID, Account)),
+                                dPort |-> DeCrypt(Head(AuthChannel).SvrPort, GetKey(Head(AuthChannel).ClientID, Account)),
+                                protocol |-> "TCP",
+                                action |-> "Accept"],
+                            "Add" \* The instruction code is to Add a new rule.
+                        )
+                    /\ SDPSucSession' = SDPSucSession \union {Head(AuthChannel)} \*record in log
+                    /\ AuthChannel' = Tail(AuthChannel)
+                    /\ UNCHANGED user_vars
+                    /\ UNCHANGED << SDPSvrState, Account, SDPSvrInfo, ReplayCount, SpoofCount, ReplaySession, SpoofSession >>
+                    /\ UNCHANGED fw_vars
+                    /\ UNCHANGED attacker_vars
+                    /\ UNCHANGED server_vars
+                    /\ UNCHANGED << uChannel, FwDataChannel, aChannel, sChannel >>
+                
 (***************************************************************************)
 (* `^                                                                      *)
 (*  Init state description of FireWall                                     *)
@@ -654,35 +654,35 @@ FwProcEndPointAccess ==
     /\ FwState = "Work"
     /\ FwDataChannel /= <<>>
     /\ (
-        \/ Head(FwDataChannel).Flg = "TCP_SYN" \* to simplify the model, we only consider TCP connection proceudre for data access
-        \/ Head(FwDataChannel).Flg = "TCP_ACK" \* the end point euipments as TCP client, only send TCP_SYN and TCP_ACK packet to target server.
-    )
+                \/ Head(FwDataChannel).Flg = "TCP_SYN" \* to simplify the model, we only consider TCP connection proceudre for data access
+                \/ Head(FwDataChannel).Flg = "TCP_ACK" \* the end point euipments as TCP client, only send TCP_SYN and TCP_ACK packet to target server.
+        )
     /\ (IF AclMatch4Tuple(Head(FwDataChannel), AclRuleSet)
-        THEN \*CASE1 : the incoming packets exactly match a 4 tuple rule
-            /\ sChannel' = Append(sChannel, Head(FwDataChannel)) \* route the packets to target server
-            /\ FwDataChannel' = Tail(FwDataChannel)
-            /\ AclRuleSet' = AclRuleSet
-            /\ DropPackets' = DropPackets
-        ELSE
-        (IF AclMatch3Tuple(Head(FwDataChannel), AclRuleSet)
-            THEN \*CASE2 : the incoming packets only match a 3 tuple rule
+            THEN \*CASE1 : the incoming packets exactly match a 4 tuple rule
                 /\ sChannel' = Append(sChannel, Head(FwDataChannel)) \* route the packets to target server
-                /\ AclRuleSet' = AclRuleSet \union {CreateRelatedRule(Head(FwDataChannel))}
-                /\ FwDataChannel' = Tail(FwDataChannel) \* This is a new TCP link, so create a exactly matched 4 tuple rule and add it to rule table
-                /\ DropPackets' = DropPackets
-            ELSE \*CASE3 : the incoming packets not match any rule
                 /\ FwDataChannel' = Tail(FwDataChannel)
                 /\ AclRuleSet' = AclRuleSet
-                /\ sChannel' = sChannel \*just drop the packets
-                /\ DropPackets' = DropPackets \union {Head(FwDataChannel)} \* record it into exception log 
+                /\ DropPackets' = DropPackets
+            ELSE
+            (IF AclMatch3Tuple(Head(FwDataChannel), AclRuleSet)
+                THEN \*CASE2 : the incoming packets only match a 3 tuple rule
+                    /\ sChannel' = Append(sChannel, Head(FwDataChannel)) \* route the packets to target server
+                    /\ AclRuleSet' = AclRuleSet \union {CreateRelatedRule(Head(FwDataChannel))}
+                    /\ FwDataChannel' = Tail(FwDataChannel) \* This is a new TCP link, so create a exactly matched 4 tuple rule and add it to rule table
+                    /\ DropPackets' = DropPackets
+                ELSE \*CASE3 : the incoming packets not match any rule
+                    /\ FwDataChannel' = Tail(FwDataChannel)
+                    /\ AclRuleSet' = AclRuleSet
+                    /\ sChannel' = sChannel \*just drop the packets
+                    /\ DropPackets' = DropPackets \union {Head(FwDataChannel)} \* record it into exception log 
+            )
         )
-    )
-    /\ UNCHANGED user_vars
-    /\ UNCHANGED sdpsvr_vars
-    /\ UNCHANGED attacker_vars
-    /\ UNCHANGED << FwState, AgedRuleSet >>
-    /\ UNCHANGED server_vars
-    /\ UNCHANGED << uChannel, AuthChannel, FwCtlChannel, aChannel >>
+        /\ UNCHANGED user_vars
+        /\ UNCHANGED sdpsvr_vars
+        /\ UNCHANGED attacker_vars
+        /\ UNCHANGED << FwState, AgedRuleSet >>
+        /\ UNCHANGED server_vars
+        /\ UNCHANGED << uChannel, AuthChannel, FwCtlChannel, aChannel >>
 
 \* Action 7: FwProcAclTimeOut
 \* A 3 Tuple ACL Rule configured by SDP controller automatically deleted due to aging mechanism.
@@ -739,46 +739,46 @@ ServerRcvTCPSyn ==
     /\ Head(sChannel).dPort = sSvrInfo.Port
     /\ sChannel' = Tail(sChannel)
     /\ (IF NewLink(Head(sChannel), sTCPLinkSet)
-        THEN \*CASE1 : New TCP SYN packets
-            /\ sTCPLinkSet' = sTCPLinkSet \union {\*create a TCB and update local link set.
-                [dIP |-> Head(sChannel).sIP,
-                    dPort |-> Head(sChannel).sPort,
-                    sIP |-> Head(sChannel).dIP,
-                    sPort |-> Head(sChannel).dPort,
-                    Type |-> Head(sChannel).Type,
-                    State |-> "SYN_RCVD" \* the TCB 's state is SYN_RCVD
-                ]}
-            /\ (IF Head(sChannel).Type = "User"
-                THEN \*If the client is legistimate user, then send TCP_SYN_ACK packet to legistimate user.
-                (
-                    /\ uChannel' = Append(uChannel, [
+            THEN \*CASE1 : New TCP SYN packets
+                /\ sTCPLinkSet' = sTCPLinkSet \union {\*create a TCB and update local link set.
+                    [dIP |-> Head(sChannel).sIP,
+                        dPort |-> Head(sChannel).sPort,
                         sIP |-> Head(sChannel).dIP,
                         sPort |-> Head(sChannel).dPort,
-                        dIP |-> Head(sChannel).sIP,
-                        dPort |-> Head(sChannel).sPort,
-                        Flg |-> "TCP_SYN_ACK",
-                        Type |-> Head(sChannel).Type]
+                        Type |-> Head(sChannel).Type,
+                        State |-> "SYN_RCVD" \* the TCB 's state is SYN_RCVD
+                    ]}
+                /\ (IF Head(sChannel).Type = "User"
+                        THEN \*If the client is legistimate user, then send TCP_SYN_ACK packet to legistimate user.
+                        (
+                            /\ uChannel' = Append(uChannel, [
+                                        sIP |-> Head(sChannel).dIP,
+                                        sPort |-> Head(sChannel).dPort,
+                                        dIP |-> Head(sChannel).sIP,
+                                        dPort |-> Head(sChannel).sPort,
+                                        Flg |-> "TCP_SYN_ACK",
+                                        Type |-> Head(sChannel).Type]
+                                )
+                            /\ aChannel' = aChannel
+                        )
+                        ELSE \*If the client is attacker, then send TCP_SYN_ACK packet to attacker.
+                        (
+                            /\ aChannel' = Append(aChannel, [
+                                        sIP |-> Head(sChannel).dIP,
+                                        sPort |-> Head(sChannel).dPort,
+                                        dIP |-> Head(sChannel).sIP,
+                                        dPort |-> Head(sChannel).sPort,
+                                        Flg |-> "TCP_SYN_ACK",
+                                        Type |-> Head(sChannel).Type]
+                                )
+                            /\ uChannel' = uChannel
+                        )
                     )
-                    /\ aChannel' = aChannel
-                )
-                ELSE \*If the client is attacker, then send TCP_SYN_ACK packet to attacker.
-                (
-                    /\ aChannel' = Append(aChannel, [
-                        sIP |-> Head(sChannel).dIP,
-                        sPort |-> Head(sChannel).dPort,
-                        dIP |-> Head(sChannel).sIP,
-                        dPort |-> Head(sChannel).sPort,
-                        Flg |-> "TCP_SYN_ACK",
-                        Type |-> Head(sChannel).Type]
-                    )
-                    /\ uChannel' = uChannel
-                )
-            )
-        ELSE \*CASE2 : duplicated TCP SYN packet,just neglect it for we don't focus on TCP SYN Flood attack.
-            /\ sTCPLinkSet' = sTCPLinkSet
-            /\ aChannel' = aChannel
-            /\ uChannel' = uChannel
-    )
+            ELSE \*CASE2 : duplicated TCP SYN packet,just neglect it for we don't focus on TCP SYN Flood attack.
+                /\ sTCPLinkSet' = sTCPLinkSet
+                /\ aChannel' = aChannel
+                /\ uChannel' = uChannel
+        )
     /\ UNCHANGED user_vars
     /\ UNCHANGED sdpsvr_vars
     /\ UNCHANGED attacker_vars
@@ -1245,17 +1245,17 @@ CliSvrLinkMatch(c, s) ==
 UserAccessAvailProperty ==
 <>[](
     /\ (\A x \in uTCPLinkSet:
-        \/ (
-            /\ x.State = "ESTABLISHED" \* scenario1: TCP link established, and exactly matched Acl Rule available in FW.  
-            /\ \E y \in sTCPLinkSet: (CliSvrLinkMatch(x, y) /\ x.State = y.State)
-            /\ AclMatch4Tuple(x, AclRuleSet)
+                    \/ (
+                                /\ x.State = "ESTABLISHED" \* scenario1: TCP link established, and exactly matched Acl Rule available in FW.  
+                                /\ \E y \in sTCPLinkSet: (CliSvrLinkMatch(x, y) /\ x.State = y.State)
+                                /\ AclMatch4Tuple(x, AclRuleSet)
+                        )
+                    \/ (
+                                /\ x.State = "SYN_SENT" \* scenario2: TCP link half-established due to 3 tuple Acl Rule aged in FW.
+                                /\ \A y \in sTCPLinkSet: ~CliSvrLinkMatch(x, y)
+                                /\ AclMatch3Tuple(x, AgedRuleSet)
+                        )
         )
-        \/ (
-            /\ x.State = "SYN_SENT" \* scenario2: TCP link half-established due to 3 tuple Acl Rule aged in FW.
-            /\ \A y \in sTCPLinkSet: ~CliSvrLinkMatch(x, y)
-            /\ AclMatch3Tuple(x, AgedRuleSet)
-        )
-    )
     /\ uTCPLinkSet /= {}
 )
 
@@ -1325,10 +1325,10 @@ FwCorrectProperty == \*to simplify the model, we don't consider TCP packets re-t
             WithDropPkts(x)
     
     /\ \A x \in uTCPLinkSet: IF x.State = "ESTABLISHED"
-        THEN
-            WithOutDropPkts(x)
-        ELSE
-            WithDropPkts(x)
+            THEN
+                WithOutDropPkts(x)
+            ELSE
+                WithDropPkts(x)
 )
 ================================================================================
 \* Modification History

--- a/libtlafmt/tests/snapshots/format__corpus@SchedulingAllocator.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@SchedulingAllocator.tla.snap
@@ -146,13 +146,13 @@ AllocatorInvariant == \** a lower-level invariant
         \A i \in DOMAIN sched: unsat[sched[i]] /= {}
     /\ \** all clients that need to be scheduled have outstanding requests
         \A c \in toSchedule: unsat[c] /= {}
-    /\ \** clients never hold a resource requested by a process earlier
-       \** in the schedule
-        \A i \in DOMAIN sched: \A j \in 1..i - 1:
-            alloc[sched[i]] \intersect unsat[sched[j]] = {}
-    /\ \** the allocator can satisfy the requests of any scheduled client
-       \** assuming that the clients scheduled earlier release their resources
-        \A i \in DOMAIN sched: unsat[sched[i]] \subseteq PrevResources(i)
+    /\   \** clients never hold a resource requested by a process earlier
+         \** in the schedule
+            \A i \in DOMAIN sched: \A j \in 1..i - 1:
+                alloc[sched[i]] \intersect unsat[sched[j]] = {}
+    /\   \** the allocator can satisfy the requests of any scheduled client
+         \** assuming that the clients scheduled earlier release their resources
+            \A i \in DOMAIN sched: unsat[sched[i]] \subseteq PrevResources(i)
 
 ClientsWillReturn ==
     \A c \in Clients: (unsat[c] = {} ~> alloc[c] = {})

--- a/libtlafmt/tests/snapshots/format__corpus@SimKnuthYao.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@SimKnuthYao.tla.snap
@@ -9,29 +9,29 @@ EXTENDS KnuthYao, Integers, Functions, CSV, TLC, TLCExt, IOUtils, Statistics
 StatelessCrookedCoin ==
     \* 3/8 tails, 5/8 heads.
     /\ IF RandomElement(1..8) \in 1..3
-    THEN
-        /\ flip' = "T"
-        \* Multiplying these probabilities quickly overflows TLC's dyadic rationals.
-        \* /\ p' = Reduce([ num |-> p.num * 3, den |-> p.den * 8 ])
-    ELSE
-        /\ flip' = "H"
-        \* /\ p' = Reduce([ num |-> p.num * 5, den |-> p.den * 8 ])
-        \* Statistically, modeling the crooked coin with a disjunct is the same, 
-        \* but the generator won't extend the behavior if both disjuncts evaluate
-        \* to false. Confirm by running the generator with a fixed number of traces
-        \* and see how PostCondition is violated.
-        \* /\ \/ /\ RandomElement(1..10) \in 4..10
-        \*       /\ flip' = "H"
-        \*    \/ /\ RandomElement(1..10) \in 1..3
-        \*       /\ flip' = "T"
+        THEN
+            /\ flip' = "T"
+            \* Multiplying these probabilities quickly overflows TLC's dyadic rationals.
+            \* /\ p' = Reduce([ num |-> p.num * 3, den |-> p.den * 8 ])
+        ELSE
+            /\ flip' = "H"
+            \* /\ p' = Reduce([ num |-> p.num * 5, den |-> p.den * 8 ])
+            \* Statistically, modeling the crooked coin with a disjunct is the same, 
+            \* but the generator won't extend the behavior if both disjuncts evaluate
+            \* to false. Confirm by running the generator with a fixed number of traces
+            \* and see how PostCondition is violated.
+            \* /\ \/ /\ RandomElement(1..10) \in 4..10
+            \*       /\ flip' = "H"
+            \*    \/ /\ RandomElement(1..10) \in 1..3
+            \*       /\ flip' = "T"
 
 --------------------------------------------------------------------------------
 
 StatefulCrookedCoin ==
     \* Crooked coin: Decreasing chance of a tail over time.
     /\ IF RandomElement(1..p.den) = 1
-    THEN flip' = "T"
-    ELSE flip' = "H"
+        THEN flip' = "T"
+        ELSE flip' = "H"
 
 --------------------------------------------------------------------------------
 

--- a/libtlafmt/tests/snapshots/format__corpus@Simple.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Simple.tla.snap
@@ -126,7 +126,7 @@ Inv ==
     /\
         \/ \E i \in 0..(N - 1): pc[i] /= "Done"
         \/ \E i \in 0..(N - 1): y[i] = 1
-    
+        
 (***************************************************************************)
 (* Here is the proof of correctness.  The top-level steps <1>1 - <1>4 are  *)
 (* the standard ones for an invariance proof, and the decomposition of the *)

--- a/libtlafmt/tests/snapshots/format__corpus@SimpleRegular.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@SimpleRegular.tla.snap
@@ -143,7 +143,7 @@ Inv ==
     /\
         \/ \E i \in 0..(N - 1): pc[i] /= "Done"
         \/ \E i \in 0..(N - 1): y[i] = 1
-    
+        
 (***************************************************************************)
 (* The proof of invariance of PCorrect differs from the proof in module    *)
 (* Simple only because the single action a has been replaced by the two    *)

--- a/libtlafmt/tests/snapshots/format__corpus@SingleLaneBridge.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@SingleLaneBridge.tla.snap
@@ -45,10 +45,10 @@ NextLocation(car) == IF car \in CarsRight THEN RMove(Location[car]) ELSE LMove(L
 
 ChangeLocation(car) ==
     /\ IF
-        \/ car \in CarsRight /\ NextLocation(car) = EndBridge + 1
-        \/ car \in CarsLeft /\ NextLocation(car) = StartBridge - 1
-    THEN WaitingBeforeBridge' = Append(WaitingBeforeBridge, car)
-    ELSE UNCHANGED WaitingBeforeBridge
+            \/ car \in CarsRight /\ NextLocation(car) = EndBridge + 1
+            \/ car \in CarsLeft /\ NextLocation(car) = StartBridge - 1
+        THEN WaitingBeforeBridge' = Append(WaitingBeforeBridge, car)
+        ELSE UNCHANGED WaitingBeforeBridge
     /\ Location' = [Location EXCEPT ![car] = NextLocation(car)]
 
 HaveSameDirection(car) ==

--- a/libtlafmt/tests/snapshots/format__corpus@SmokeEWD998.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@SmokeEWD998.tla.snap
@@ -33,7 +33,7 @@ SmokeInit ==
         /\ color \in RandomSubset(k, [Node -> Color])
         /\ token \in RandomSubset(k, [pos: Node, q: Node, color: ({"black"})])
         /\ Inv!P0 \* Reject states with invalid ratio between counter, pending, ...
-    
+        
 \* StopAfter  has to be configured as a state constraint. It stops TLC after ~1
 \* second or after generating 100 traces, whatever comes first, unless TLC
 \* encountered an error.  In this case,  StopAfter  has no relevance.

--- a/libtlafmt/tests/snapshots/format__corpus@SpanTree.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@SpanTree.tla.snap
@@ -110,7 +110,7 @@ PostCondition ==
             /\ dist[n] \in 1..(MaxCardinality - 1)
             /\ mom[n] \in Nbrs(n)
             /\ dist[n] = dist[mom[n]] + 1
-        
+            
 (***************************************************************************)
 (* ENABLED Next is the TLA+ formula that is true of a state iff (if and    *)
 (* only if) there is a step satisfying Next starting in the state.  Thus,  *)

--- a/libtlafmt/tests/snapshots/format__corpus@Synod.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Synod.tla.snap
@@ -29,12 +29,12 @@ IInit ==
 IChoose(p) ==
     /\ output[p] = NotAnInput
     /\ IF chosen = NotAnInput
-    THEN \E ip \in allInput:
-        /\ chosen' = ip
-        /\ output' = [output EXCEPT ![p] = ip]
-    ELSE
-        /\ output' = [output EXCEPT ![p] = chosen]
-        /\ UNCHANGED chosen
+        THEN \E ip \in allInput:
+            /\ chosen' = ip
+            /\ output' = [output EXCEPT ![p] = ip]
+        ELSE
+            /\ output' = [output EXCEPT ![p] = chosen]
+            /\ UNCHANGED chosen
     /\ UNCHANGED << input, allInput >>
 
 IFail(p) ==

--- a/libtlafmt/tests/snapshots/format__corpus@TLCMC.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@TLCMC.tla.snap
@@ -205,20 +205,20 @@ Init == (* Global variables *)
 init ==
     /\ pc = "init"
     /\ IF i <= Len(S)
-    THEN
-        /\ state' = S[i]
-        /\ C' = (C \union {state'})
-        /\ i' = i + 1
-        /\ IF state' \in ViolationStates
         THEN
-            /\ counterexample' = << state' >>
-            /\ pc' = "trc"
+            /\ state' = S[i]
+            /\ C' = (C \union {state'})
+            /\ i' = i + 1
+            /\ IF state' \in ViolationStates
+                THEN
+                    /\ counterexample' = << state' >>
+                    /\ pc' = "trc"
+                ELSE
+                    /\ pc' = "init"
+                    /\ UNCHANGED counterexample
         ELSE
-            /\ pc' = "init"
-            /\ UNCHANGED counterexample
-    ELSE
-        /\ pc' = "initPost"
-        /\ UNCHANGED << C, state, i, counterexample >>
+            /\ pc' = "initPost"
+            /\ UNCHANGED << C, state, i, counterexample >>
     /\ UNCHANGED << S, successors, T >>
 
 initPost ==
@@ -231,56 +231,56 @@ initPost ==
 scsr ==
     /\ pc = "scsr"
     /\ IF Len(S) /= 0
-    THEN
-        /\ state' = Head(S)
-        /\ S' = Tail(S)
-        /\ successors' = SuccessorsOf(state', StateGraph) \ C
-        /\ IF SuccessorsOf(state', StateGraph) = {}
         THEN
-            /\ counterexample' = << state' >>
-            /\ pc' = "trc"
+            /\ state' = Head(S)
+            /\ S' = Tail(S)
+            /\ successors' = SuccessorsOf(state', StateGraph) \ C
+            /\ IF SuccessorsOf(state', StateGraph) = {}
+                THEN
+                    /\ counterexample' = << state' >>
+                    /\ pc' = "trc"
+                ELSE
+                    /\ pc' = "each"
+                    /\ UNCHANGED counterexample
         ELSE
-            /\ pc' = "each"
-            /\ UNCHANGED counterexample
-    ELSE
-        /\ Assert(S = <<>> /\ ViolationStates = {},
-            "Failure of assertion at line 164, column 8.")
-        /\ pc' = "Done"
-        /\ UNCHANGED << S, state, successors, counterexample >>
+            /\ Assert(S = <<>> /\ ViolationStates = {},
+                "Failure of assertion at line 164, column 8.")
+            /\ pc' = "Done"
+            /\ UNCHANGED << S, state, successors, counterexample >>
     /\ UNCHANGED << C, i, T >>
 
 each ==
     /\ pc = "each"
     /\ IF successors /= {}
-    THEN
-        /\ \E succ \in successors:
-            /\ successors' = successors \ {succ}
-            /\ C' = (C \union {succ})
-            /\ S' = S \o << succ >>
-            /\ T' = T \o << << state, succ >> >>
-            /\ IF succ \in ViolationStates
-            THEN
-                /\ counterexample' = << succ >>
-                /\ pc' = "trc"
-            ELSE
-                /\ pc' = "each"
-                /\ UNCHANGED counterexample
-    ELSE
-        /\ pc' = "scsr"
-        /\ UNCHANGED << S, C, successors, counterexample, T >>
+        THEN
+            /\ \E succ \in successors:
+                /\ successors' = successors \ {succ}
+                /\ C' = (C \union {succ})
+                /\ S' = S \o << succ >>
+                /\ T' = T \o << << state, succ >> >>
+                /\ IF succ \in ViolationStates
+                    THEN
+                        /\ counterexample' = << succ >>
+                        /\ pc' = "trc"
+                    ELSE
+                        /\ pc' = "each"
+                        /\ UNCHANGED counterexample
+        ELSE
+            /\ pc' = "scsr"
+            /\ UNCHANGED << S, C, successors, counterexample, T >>
     /\ UNCHANGED << state, i >>
 
 trc ==
     /\ pc = "trc"
     /\ IF Head(counterexample) \notin StateGraph.initials
-    THEN
-        /\ counterexample' = << Predecessor(T, Head(counterexample)) >> \o counterexample
-        /\ pc' = "trc"
-    ELSE
-        /\ Assert(counterexample /= <<>>,
-            "Failure of assertion at line 177, column 20.")
-        /\ pc' = "Done"
-        /\ UNCHANGED counterexample
+        THEN
+            /\ counterexample' = << Predecessor(T, Head(counterexample)) >> \o counterexample
+            /\ pc' = "trc"
+        ELSE
+            /\ Assert(counterexample /= <<>>,
+                "Failure of assertion at line 177, column 20.")
+            /\ pc' = "Done"
+            /\ UNCHANGED counterexample
     /\ UNCHANGED << S, C, state, successors, i, T >>
 
 (* Allow infinite stuttering to prevent deadlock on termination. *)

--- a/libtlafmt/tests/snapshots/format__corpus@Voting.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@Voting.tla.snap
@@ -174,7 +174,7 @@ ShowsSafeAt(Q, b, v) ==
     /\ \E c \in - 1..(b - 1):
         /\ (c /= - 1) => \E a \in Q: VotedFor(a, c, v)
         /\ \A d \in (c + 1)..(b - 1), a \in Q: DidNotVoteAt(a, d)
-        
+            
 (***************************************************************************)
 (* This is the theorem that's at the heart of the algorithm.  It shows     *)
 (* that if the algorithm has maintained the invariance of Inv, then the    *)

--- a/libtlafmt/tests/snapshots/format__corpus@WriteThroughCacheInstanced.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@WriteThroughCacheInstanced.tla.snap
@@ -52,8 +52,8 @@ M_Req(p) ==
 M_Do(p) ==
     /\ ctl[p] = "busy"
     /\ wmem' = IF buf[p].op = "Wr"
-    THEN [wmem EXCEPT ![buf[p].adr] = buf[p].val]
-    ELSE wmem
+        THEN [wmem EXCEPT ![buf[p].adr] = buf[p].val]
+        ELSE wmem
     /\ buf' = [buf EXCEPT ![p] = IF buf[p].op = "Wr"
         THEN NoVal
         ELSE wmem[buf[p].adr]]

--- a/libtlafmt/tests/snapshots/format__corpus@YoYoAllGraphs.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@YoYoAllGraphs.tla.snap
@@ -1,0 +1,253 @@
+---
+source: libtlafmt/tests/format.rs
+expression: output
+input_file: libtlafmt/tests/corpus/YoYoAllGraphs.tla
+---
+----------------------------- MODULE YoYoAllGraphs -----------------------------
+(****************************************************************************)
+(* This module describes the Yo-Yo algorithm with pruning. Unlike the basic *)
+(* specification of that algorithm in module YoYoPruning, it allows the     *)
+(* algorithm to be verified for all undirected, loop-free, and connected    *)
+(* graphs over a fixed number of nodes.                                     *)
+(*                                                                          *)
+(* Authors: Ludovic Yvoz and Stephan Merz, 2024.                            *)
+(****************************************************************************)
+
+EXTENDS TLC, Integers, FiniteSets, UndirectedGraphs
+
+CONSTANT N \* number of nodes
+
+ASSUME N \in Nat \ {0}
+
+Nodes == 1..N
+(****************************************************************************)
+(* Set of all (non-loop) edges over the set of nodes. The algorithm will    *)
+(* operate over a subset of edges that forms a connected graph.             *)
+(****************************************************************************)
+Edges == {{e[1], e[2]}: e \in {e \in Nodes \X Nodes: e[1] /= e[2]}}
+
+Min(S) == CHOOSE x \in S: \A y \in S: x <= y
+
+VARIABLES
+    (* the activation status of the node *)
+    active,
+    (* the phase (down or up) each node is currently executing *)
+    phase,
+    (* incoming and outgoing neighbors of each node *)
+    incoming, outgoing,
+    (* mailbox of each node *)
+    mailbox
+
+vars == << active, phase, incoming, outgoing, mailbox >>
+
+(****************************************************************************)
+(* Determine the kind of the node: leader, source, sink or internal.        *)
+(****************************************************************************)
+kind(n) ==
+    IF incoming[n] = {} /\ outgoing[n] = {} THEN "leader"
+    ELSE IF incoming[n] = {} THEN "source"
+        ELSE IF outgoing[n] = {} THEN "sink"
+            ELSE "internal"
+
+(****************************************************************************)
+(* Messages sent during the algorithm.                                      *)
+(****************************************************************************)
+Messages ==
+    [phase: {"down"}, sndr: Nodes, val: Nodes] \union
+        [phase: {"up"}, sndr: Nodes, reply: {"yes", "no"}, prune: BOOLEAN ]
+downMsg(s, v) == [phase |-> "down", sndr |-> s, val |-> v]
+upMsg(s, r, p) == [phase |-> "up", sndr |-> s, reply |-> r, prune |-> p]
+
+(****************************************************************************)
+(* Type correctness predicate.                                              *)
+(****************************************************************************)
+TypeOK ==
+    /\ active \in [Nodes -> BOOLEAN ]
+    /\ phase \in [Nodes -> {"down", "up"}]
+    /\ incoming \in [Nodes -> SUBSET Nodes]
+    /\ outgoing \in [Nodes -> SUBSET Nodes]
+    /\ mailbox \in [Nodes -> SUBSET Messages]
+    /\ \A n \in Nodes: \A msg \in mailbox[n]:
+        /\ msg.phase = "down" =>
+            /\ n \in outgoing[msg.sndr]
+            /\ \A mm \in mailbox[n]: \* at most one message per neighbor
+                mm.phase = "down" /\ mm.sndr = msg.sndr => mm = msg
+        /\ msg.phase = "up" =>
+                /\ msg.sndr \in outgoing[n]
+                /\ \A mm \in mailbox[n]: \* at most one message per neighbor
+                    mm.phase = "up" /\ mm.sndr = msg.sndr => mm = msg
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Yo-Yo algorithm as a state machine.                                      *)
+(****************************************************************************)
+Init ==
+    /\ active = [n \in Nodes |-> TRUE]
+    /\ phase = [n \in Nodes |-> "down"]
+    /\ mailbox = [n \in Nodes |-> {}]
+    /\ \E Nbrs \in SUBSET Edges:
+        \* true by construction
+        \* /\ IsLoopFreeUndirectedGraph([node |-> Nodes, edge |-> Nbrs])
+            /\ IsStronglyConnected([node |-> Nodes, edge |-> Nbrs])
+            /\ incoming = [n \in Nodes |-> {m \in Nodes: {m, n} \in Nbrs /\ m < n}]
+            /\ outgoing = [n \in Nodes |-> {m \in Nodes: {m, n} \in Nbrs /\ m > n}]
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Down phase: we distinguish sources and other nodes.                      *)
+(* Note that a node retains "down" messages after executing the phase       *)
+(* because they are used during the up phase.                               *)
+(****************************************************************************)
+DownSource(n) ==
+    /\ active[n]
+    /\ kind(n) = "source"
+    /\ phase[n] = "down"
+    /\ mailbox' = [m \in Nodes |->
+        IF m \in outgoing[n] THEN mailbox[m] \union {downMsg(n, n)}
+        ELSE mailbox[m]]
+    /\ phase' = [phase EXCEPT ![n] = "up"]
+    /\ UNCHANGED << active, incoming, outgoing >>
+
+DownOther(n) ==
+    /\ active[n]
+    /\ kind(n) \in {"internal", "sink"}
+    /\ phase[n] = "down"
+    /\ LET downMsgs == {msg \in mailbox[n]: msg.phase = "down"}
+        IN
+            /\ {msg.sndr: msg \in downMsgs} = incoming[n]
+            /\ LET min == Min({msg.val: msg \in downMsgs})
+                IN mailbox' = [m \in Nodes |->
+                    IF m \in outgoing[n]
+                    THEN mailbox[m] \union {downMsg(n, min)}
+                    ELSE mailbox[m]]
+    /\ phase' = [phase EXCEPT ![n] = "up"]
+    /\ UNCHANGED << active, incoming, outgoing >>
+
+Down(n) == DownSource(n) \/ DownOther(n)
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Up phase, again distinguishing sources and other nodes.                  *)
+(*                                                                          *)
+(* An internal or source node may already have received "down" messages     *)
+(* for the following round from neighbors that it still considers as        *)
+(* outgoing neighbors but for which the edge direction was reversed.        *)
+(* We therefore have to be careful to only consider "down" messages from    *)
+(* neighbors that the node considers as incoming, and also to preserve      *)
+(* "down" messages for the following round when cleaning the mailbox.       *)
+(****************************************************************************)
+UpSource(n) ==
+    /\ active[n]
+    /\ kind(n) = "source"
+    /\ phase[n] = "up"
+    /\ LET upMsgs == {msg \in mailbox[n]: msg.phase = "up"}
+            noSndrs == {msg.sndr: msg \in {mm \in upMsgs: mm.reply = "no"}}
+            pruned == {msg.sndr: msg \in {mm \in upMsgs: mm.prune}}
+        IN
+        /\ {msg.sndr: msg \in upMsgs} = outgoing[n]
+        /\ mailbox' = [mailbox EXCEPT ![n] = mailbox[n] \ upMsgs]
+        /\ incoming' = [incoming EXCEPT ![n] = noSndrs \ pruned]
+        /\ outgoing' = [outgoing EXCEPT ![n] = @ \ (noSndrs \union pruned)]
+    /\ phase' = [phase EXCEPT ![n] = "down"]
+    /\ active' = active
+
+UpOther(n) ==
+    /\ active[n]
+    /\ kind(n) \in {"internal", "sink"}
+    /\ phase[n] = "up"
+    /\ LET upMsgs == {msg \in mailbox[n]: msg.phase = "up"}
+            noSndrs == {msg.sndr: msg \in {mm \in upMsgs: mm.reply = "no"}}
+            pruned == {msg.sndr: msg \in {mm \in upMsgs: mm.prune}}
+            downMsgs == {msg \in mailbox[n]: msg.phase = "down" /\ msg.sndr \in incoming[n]}
+            valsRcvd == {msg.val: msg \in downMsgs}
+            senders(v) == {m \in incoming[n]: downMsg(m, v) \in downMsgs}
+            valSent(m) == (CHOOSE msg \in downMsgs: msg.sndr = m).val
+            isLoneSink == kind(n) = "sink" /\ Cardinality(incoming[n]) = 1
+        IN
+        /\ {msg.sndr: msg \in upMsgs} = outgoing[n] \* always true for sinks
+        /\    \* non-deterministically choose a sender for each value whose link
+              \* will not be pruned
+                \E keep \in {f \in [valsRcvd -> incoming[n]]:
+                        \A v \in valsRcvd: f[v] \in senders(v)}:
+                    /\ IF noSndrs = {} \* true in particular for sinks
+                        THEN LET min == Min({msg.val: msg \in downMsgs})
+                                minSndrs == {msg.sndr: msg \in {mm \in downMsgs: mm.val = min}}
+                            IN
+                            /\ mailbox' = [m \in Nodes |->
+                                IF m \in incoming[n]
+                                THEN mailbox[m] \union
+                                    {upMsg(n,
+                                        IF m \in minSndrs THEN "yes" ELSE "no",
+                                        (m /= keep[valSent(m)]) \/ isLoneSink)}
+                                ELSE IF m = n THEN mailbox[m] \ (upMsgs \union downMsgs)
+                                    ELSE mailbox[m]]
+                            /\ incoming' = [incoming EXCEPT ![n] =
+                                    IF isLoneSink THEN {} ELSE {keep[min]}]
+                            /\ outgoing' = [outgoing EXCEPT ![n] =
+                                    (@ \ pruned) \union
+                                        {keep[v]: v \in valsRcvd \ {min}}]
+                        ELSE
+                            /\ mailbox' = [m \in Nodes |->
+                                    IF m \in incoming[n]
+                                    THEN mailbox[m] \union {upMsg(n, "no", m /= keep[valSent(m)])}
+                                    ELSE IF m = n THEN mailbox[m] \ (upMsgs \union downMsgs)
+                                        ELSE mailbox[m]]
+                            /\ incoming' = [incoming EXCEPT ![n] = noSndrs \ pruned]
+                            /\ outgoing' = [outgoing EXCEPT ![n] =
+                                    (@ \ (noSndrs \union pruned)) \union
+                                        {keep[v]: v \in valsRcvd}]
+                    /\ active' = [active EXCEPT ![n] = ~isLoneSink]
+    /\ phase' = [phase EXCEPT ![n] = "down"]
+
+Up(n) == UpSource(n) \/ UpOther(n)
+
+--------------------------------------------------------------------------------
+
+Next == \E n \in Nodes: Down(n) \/ Up(n)
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Formulas used for verification.                                          *)
+(****************************************************************************)
+
+(****************************************************************************)
+(* Predicate asserting that there will always be at least two source nodes. *)
+(* Checking this as an invariant produces an execution that shows that all  *)
+(* sources except for the leader will be eliminated.                        *)
+(****************************************************************************)
+MoreThanOneSource == \E s1, s2 \in Nodes:
+    s1 /= s2 /\ kind(s1) = "source" /\ kind(s2) = "source"
+
+(****************************************************************************)
+(* Node m is an outgoing neighbor of node n iff n is an incoming neighbor   *)
+(* of m, except if the edge is being reversed, in which case there is a     *)
+(* "no" message in one of the mailboxes, or if the edge is being pruned,    *)
+(* in which case there is a corresponding message pending at node n.        *)
+(****************************************************************************)
+NeighborInv == \A m, n \in Nodes:
+    m \in outgoing[n] <=>
+        \/ n \in incoming[m]
+        \/
+            /\ n \in outgoing[m]
+            /\
+                \/ upMsg(n, "no", FALSE) \in mailbox[m]
+                \/ upMsg(m, "no", FALSE) \in mailbox[n]
+        \/
+                /\ n \notin (incoming[m] \union outgoing[m])
+                /\ \E r \in {"yes", "no"}: upMsg(m, r, TRUE) \in mailbox[n]
+                
+(****************************************************************************)
+(* Termination condition: the node with smallest identity is the leader,    *)
+(* all other nodes are inactive, all mailboxes are empty.                   *)
+(* Check that the algorithm will reach such a state, and that this is the   *)
+(* only final (deadlock) state.                                             *)
+(****************************************************************************)
+Termination == \A n \in Nodes:
+        /\ IF n = Min(Nodes) THEN kind(n) = "leader" ELSE ~active[n]
+        /\ mailbox[n] = {}
+
+Liveness == <>Termination
+FinishIffTerminated == ~(ENABLED Next) <=> Termination
+================================================================================

--- a/libtlafmt/tests/snapshots/format__corpus@YoYoNoPruning.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@YoYoNoPruning.tla.snap
@@ -1,0 +1,262 @@
+---
+source: libtlafmt/tests/format.rs
+expression: output
+input_file: libtlafmt/tests/corpus/YoYoNoPruning.tla
+---
+----------------------------- MODULE YoYoNoPruning -----------------------------
+(****************************************************************************)
+(* TLA+ specification of the Yo-Yo leader election algorithm in arbitrary   *)
+(* undirected graphs without self-loops. The algorithm was introduced by    *)
+(* Nicola Santoro, cf. "Design and Analysis of Distributed Algorithms",     *)
+(* section 3.8.3, see also https://en.wikipedia.org/wiki/Yo-yo_(algorithm). *)
+(* The algorithm assumes that nodes are (identified by) integers, and the   *)
+(* node with the smallest identity will be elected leader.                  *)
+(*                                                                          *)
+(* The algorithm orients the edges of the graph. Initially, all edges are   *)
+(* directed from smaller to larger node identities, so sources correspond   *)
+(* to local minima in their neighborhoods and sinks correspond to local     *)
+(* maxima. Sources are considered candidates for being leader, and as long  *)
+(* as their are at least two sources, each round will eliminate at least    *)
+(* one of them.                                                             *)
+(*                                                                          *)
+(* Each round consists of two phases, traditionally called the "Yo-" and    *)
+(* "-Yo" phases, that will be called "down" and "up" phases below.          *)
+(* The down phase is initiated by the sources, which broadcast their        *)
+(* identity to all neighbors. Non-source nodes wait for values to have been *)
+(* received from all incoming neighbors, then broadcast the minimum value   *)
+(* that has been received to all outgoing neighbors. (Sink nodes do not     *)
+(* send messages in the down phase.)                                        *)
+(*                                                                          *)
+(* The up phase is initiated by sink nodes when they have received values   *)
+(* from all neighbors in the down phase. They reply "yes" to all neighbors  *)
+(* that sent the minimum value and "no" to all other neighbors. The other   *)
+(* nodes wait until messages for the up phase have been received from all   *)
+(* outgoing neighbors. If one message is "no", they send "no" to all        *)
+(* incoming neighbors, otherwise they send "yes" to those incoming          *)
+(* neighbors who sent the smallest value during the down phase and "no" to  *)
+(* all other incoming neighbors. (Source nodes do not send messages in the  *)
+(* up phase.)                                                               *)
+(* Moreover, edges along which a "no" message is sent during the up phase   *)
+(* change orientation. This may change the status of a node (source,        *)
+(* sink or internal).                                                       *)
+(*                                                                          *)
+(* The algorithm stabilizes in a state where there is at most one source,   *)
+(* after which point only the identity of that source will be sent during   *)
+(* the down phase and only "yes" messages will be sent during the up phase. *)
+(* However, no node detects termination. Ensuring termination of the        *)
+(* algorithm is achieved by pruning the graph, modeled in a variant of the  *)
+(* present specification.                                                   *)
+(*                                                                          *)
+(* Authors: Ludovic Yvoz and Stephan Merz, 2024.                            *)
+(****************************************************************************)
+
+EXTENDS TLC, Integers, FiniteSets, UndirectedGraphs
+
+CONSTANT Nodes, Edges \* the nodes and edges of the graph
+
+ASSUME  
+  (* nodes are represented by their integer identities *)
+  /\ Nodes \subseteq Int
+  /\ Nodes # {} 
+  /\ LET G == [node |-> Nodes, edge |-> Edges]
+     IN  /\ IsUndirectedGraph(G)
+         /\ IsStronglyConnected(G)
+
+Neighbors(n) == {m \in Nodes: {m, n} \in Edges}
+
+Min(S) == CHOOSE x \in S: \A y \in S: x <= y
+
+VARIABLES
+    (* the phase (down or up) each node is currently executing *)
+    phase,
+    (* incoming and outgoing neighbors of each node *)
+    incoming, outgoing,
+    (* mailbox of each node *)
+    mailbox
+
+vars == << phase, incoming, outgoing, mailbox >>
+
+(****************************************************************************)
+(* Determine the kind of the node: source, sink or internal.                *)
+(****************************************************************************)
+kind(n) ==
+    IF incoming[n] = {} THEN "source"
+    ELSE IF outgoing[n] = {} THEN "sink"
+        ELSE "internal"
+
+(****************************************************************************)
+(* Messages sent during the algorithm.                                      *)
+(****************************************************************************)
+Messages ==
+    [phase: {"down"}, sndr: Nodes, val: Nodes] \union
+        [phase: {"up"}, sndr: Nodes, reply: {"yes", "no"}]
+downMsg(s, v) == [phase |-> "down", sndr |-> s, val |-> v]
+upMsg(s, r) == [phase |-> "up", sndr |-> s, reply |-> r]
+
+(****************************************************************************)
+(* Type correctness predicate.                                              *)
+(****************************************************************************)
+TypeOK ==
+    /\ phase \in [Nodes -> {"down", "up"}]
+    /\ incoming \in [Nodes -> SUBSET Nodes]
+    /\ \A n \in Nodes: incoming[n] \subseteq Neighbors(n)
+    /\ outgoing \in [Nodes -> SUBSET Nodes]
+    /\ \A n \in Nodes: outgoing[n] \subseteq Neighbors(n)
+    /\ mailbox \in [Nodes -> SUBSET Messages]
+    /\ \A n \in Nodes: \A msg \in mailbox[n]:
+        /\ msg.phase = "down" =>
+            /\ n \in outgoing[msg.sndr]
+            /\ \A mm \in mailbox[n]: \* at most one message per neighbor
+                mm.phase = "down" /\ mm.sndr = msg.sndr => mm = msg
+        /\ msg.phase = "up" =>
+                /\ msg.sndr \in outgoing[n]
+                /\ \A mm \in mailbox[n]: \* at most one message per neighbor
+                    mm.phase = "up" /\ mm.sndr = msg.sndr => mm = msg
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Yo-Yo algorithm as a state machine.                                      *)
+(****************************************************************************)
+Init ==
+    /\ phase = [n \in Nodes |-> "down"]
+    /\ incoming = [n \in Nodes |-> {m \in Neighbors(n): m < n}]
+    /\ outgoing = [n \in Nodes |-> {m \in Neighbors(n): m > n}]
+    /\ mailbox = [n \in Nodes |-> {}]
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Down phase: we distinguish sources and other nodes.                      *)
+(* Note that a node retains "down" messages after executing the phase       *)
+(* because they are used during the up phase.                               *)
+(****************************************************************************)
+DownSource(n) ==
+    /\ kind(n) = "source"
+    /\ phase[n] = "down"
+    /\ mailbox' = [m \in Nodes |->
+        IF m \in outgoing[n] THEN mailbox[m] \union {downMsg(n, n)}
+        ELSE mailbox[m]]
+    /\ phase' = [phase EXCEPT ![n] = "up"]
+    /\ UNCHANGED << incoming, outgoing >>
+
+DownOther(n) ==
+    /\ kind(n) \in {"internal", "sink"}
+    /\ phase[n] = "down"
+    /\ LET downMsgs == {msg \in mailbox[n]: msg.phase = "down"}
+        IN
+            /\ {msg.sndr: msg \in downMsgs} = incoming[n]
+            /\ LET min == Min({msg.val: msg \in downMsgs})
+                IN mailbox' = [m \in Nodes |->
+                    IF m \in outgoing[n]
+                    THEN mailbox[m] \union {downMsg(n, min)}
+                    ELSE mailbox[m]]
+    /\ phase' = [phase EXCEPT ![n] = "up"]
+    /\ UNCHANGED << incoming, outgoing >>
+
+Down(n) == DownSource(n) \/ DownOther(n)
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Up phase, again distinguishing sources and other nodes.                  *)
+(*                                                                          *)
+(* An internal or source node may already have received "down" messages     *)
+(* for the following round from neighbors that it still considers as        *)
+(* outgoing neighbors but for which the edge direction was reversed.        *)
+(* We therefore have to be careful to only consider "down" messages from    *)
+(* neighbors that the node considers as incoming, and also to preserve      *)
+(* "down" messages for the following round when cleaning the mailbox.       *)
+(****************************************************************************)
+UpSource(n) ==
+    /\ kind(n) = "source"
+    /\ phase[n] = "up"
+    /\ LET upMsgs == {msg \in mailbox[n]: msg.phase = "up"}
+            noSndrs == {msg.sndr: msg \in {mm \in upMsgs: mm.reply = "no"}}
+        IN
+        /\ {msg.sndr: msg \in upMsgs} = outgoing[n]
+        /\ mailbox' = [mailbox EXCEPT ![n] = mailbox[n] \ upMsgs]
+        /\ incoming' = [incoming EXCEPT ![n] = noSndrs]
+        /\ outgoing' = [outgoing EXCEPT ![n] = @ \ noSndrs]
+    /\ phase' = [phase EXCEPT ![n] = "down"]
+
+UpOther(n) ==
+    /\ kind(n) \in {"internal", "sink"}
+    /\ phase[n] = "up"
+    /\ LET upMsgs == {msg \in mailbox[n]: msg.phase = "up"}
+            noSndrs == {msg.sndr: msg \in {mm \in upMsgs: mm.reply = "no"}}
+            downMsgs == {msg \in mailbox[n]: msg.phase = "down" /\ msg.sndr \in incoming[n]}
+        IN
+        /\ {msg.sndr: msg \in upMsgs} = outgoing[n] \* always true for sinks
+        /\ IF noSndrs = {} \* true in particular for sinks
+            THEN LET min == Min({msg.val: msg \in downMsgs})
+                    minSndrs == {msg.sndr: msg \in {mm \in downMsgs: mm.val = min}}
+                IN
+                /\ mailbox' = [m \in Nodes |->
+                    IF m \in incoming[n]
+                    THEN mailbox[m] \union
+                        {upMsg(n, IF m \in minSndrs THEN "yes" ELSE "no")}
+                    ELSE IF m = n THEN mailbox[m] \ (upMsgs \union downMsgs)
+                        ELSE mailbox[m]]
+                /\ incoming' = [incoming EXCEPT ![n] = minSndrs]
+                /\ outgoing' = [outgoing EXCEPT ![n] =
+                    @ \union (incoming[n] \ minSndrs)]
+            ELSE
+                /\ mailbox' = [m \in Nodes |->
+                    IF m \in incoming[n] THEN mailbox[m] \union {upMsg(n, "no")}
+                    ELSE IF m = n THEN mailbox[m] \ (upMsgs \union downMsgs)
+                        ELSE mailbox[m]]
+                /\ incoming' = [incoming EXCEPT ![n] = noSndrs]
+                /\ outgoing' = [outgoing EXCEPT ![n] =
+                    (@ \ noSndrs) \union incoming[n]]
+    /\ phase' = [phase EXCEPT ![n] = "down"]
+
+Up(n) == UpSource(n) \/ UpOther(n)
+
+--------------------------------------------------------------------------------
+
+Next == \E n \in Nodes: Down(n) \/ Up(n)
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Formulas used for verification.                                          *)
+(****************************************************************************)
+
+(****************************************************************************)
+(* Predicate asserting that there will always be at least two source nodes. *)
+(* Checking this as an invariant produces an execution that shows that all  *)
+(* sources except for the leader will be eliminated.                        *)
+(****************************************************************************)
+MoreThanOneSource == \E s1, s2 \in Nodes:
+    s1 /= s2 /\ kind(s1) = "source" /\ kind(s2) = "source"
+
+(****************************************************************************)
+(* Node m is an outgoing neighbor of node n iff n is an incoming neighbor   *)
+(* of m, except if the edge is being reversed, in which case there is a     *)
+(* "no" message in one of the mailboxes.                                    *)
+(****************************************************************************)
+NeighborInv == \A m, n \in Nodes:
+    m \in outgoing[n] <=>
+        \/ n \in incoming[m]
+        \/
+            /\ n \in outgoing[m]
+            /\ upMsg(n, "no") \in mailbox[m] \/ upMsg(m, "no") \in mailbox[n]
+                
+(****************************************************************************)
+(* No new sources are generated during execution of the algorithm.          *)
+(****************************************************************************)
+NoNewSource ==
+[][\A n \in Nodes : kind(n)' = "source" => kind(n) = "source"]_vars
+
+(****************************************************************************)
+(* Stabilization condition: there is only one source node, all "down"       *)
+(* messages carry the identity of that node, all "up" messages say "yes".   *)
+(****************************************************************************)
+Stabilization ==
+    /\ kind(Min(Nodes)) = "source"
+    /\ \A n \in Nodes: kind(n) = "source" => n = Min(Nodes)
+    /\ \A n \in Nodes: \A msg \in mailbox[n]:
+        /\ msg.phase = "down" => msg.val = Min(Nodes)
+        /\ msg.phase = "up" => msg.reply = "yes"
+
+Liveness == <>[]Stabilization
+================================================================================

--- a/libtlafmt/tests/snapshots/format__corpus@YoYoPruning.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@YoYoPruning.tla.snap
@@ -1,0 +1,279 @@
+---
+source: libtlafmt/tests/format.rs
+expression: output
+input_file: libtlafmt/tests/corpus/YoYoPruning.tla
+---
+------------------------------ MODULE YoYoPruning ------------------------------
+(****************************************************************************)
+(* The version of the Yo-Yo algorithm without pruning stabilizes in a state *)
+(* with a single source node. However, that algorithm does not terminate,   *)
+(* and no single node can detect that the algorithm has stabilized. In      *)
+(* order to ensure termination, the "up" ("-Yo") phase of the algorithm is  *)
+(* extended in order to prune the graph by applying the following rules.    *)
+(*                                                                          *)
+(* 1. A sink node with a single (incoming) neighbor receives only one value *)
+(*    during the "down" phase, and therefore replies "yes" in the "up"      *)
+(*    phase of the algorithm. Since it does not contribute any useful       *)
+(*    information, it will become inactive and be removed from the graph.   *)
+(* 2. A node (internal or sink) that receives the same value from several   *)
+(*    neighbors non-deterministically chooses one of these neighbors and    *)
+(*    prunes the links to all other neighbors that sent the same value.     *)
+(*    The rationale is that these neighbors correspond to different paths   *)
+(*    from the same source node, and maintaining one path is enough.        *)
+(*                                                                          *)
+(* Applying these two rules, nodes and links are eliminated until the only  *)
+(* remaining source becomes an isolated node, at which point it proclaims   *)
+(* itself to be the leader. All other nodes will have become inactive.      *)
+(* The pruning phase is implemented by adding a flag to "up" messages,      *)
+(* indicating to the receiver whether to prune the corresponding link.      *)
+(*                                                                          *)
+(* Authors: Ludovic Yvoz and Stephan Merz, 2024.                            *)
+(****************************************************************************)
+
+EXTENDS TLC, Integers, FiniteSets, UndirectedGraphs
+
+CONSTANT Nodes, Edges \* the nodes and edges of the graph
+
+ASSUME  
+  (* nodes are represented by their integer identities *)
+  /\ Nodes \subseteq Int
+  /\ Nodes # {} 
+  /\ LET G == [node |-> Nodes, edge |-> Edges]
+     IN  /\ IsUndirectedGraph(G)
+         /\ IsStronglyConnected(G)
+
+Neighbors(n) == {m \in Nodes: {m, n} \in Edges}
+
+Min(S) == CHOOSE x \in S: \A y \in S: x <= y
+
+VARIABLES
+    (* the activation status of the node *)
+    active,
+    (* the phase (down or up) each node is currently executing *)
+    phase,
+    (* incoming and outgoing neighbors of each node *)
+    incoming, outgoing,
+    (* mailbox of each node *)
+    mailbox
+
+vars == << active, phase, incoming, outgoing, mailbox >>
+
+(****************************************************************************)
+(* Determine the kind of the node: leader, source, sink or internal.        *)
+(****************************************************************************)
+kind(n) ==
+    IF incoming[n] = {} /\ outgoing[n] = {} THEN "leader"
+    ELSE IF incoming[n] = {} THEN "source"
+        ELSE IF outgoing[n] = {} THEN "sink"
+            ELSE "internal"
+
+(****************************************************************************)
+(* Messages sent during the algorithm.                                      *)
+(****************************************************************************)
+Messages ==
+    [phase: {"down"}, sndr: Nodes, val: Nodes] \union
+        [phase: {"up"}, sndr: Nodes, reply: {"yes", "no"}, prune: BOOLEAN ]
+downMsg(s, v) == [phase |-> "down", sndr |-> s, val |-> v]
+upMsg(s, r, p) == [phase |-> "up", sndr |-> s, reply |-> r, prune |-> p]
+
+(****************************************************************************)
+(* Type correctness predicate.                                              *)
+(****************************************************************************)
+TypeOK ==
+    /\ active \in [Nodes -> BOOLEAN ]
+    /\ phase \in [Nodes -> {"down", "up"}]
+    /\ incoming \in [Nodes -> SUBSET Nodes]
+    /\ \A n \in Nodes: incoming[n] \subseteq Neighbors(n)
+    /\ outgoing \in [Nodes -> SUBSET Nodes]
+    /\ \A n \in Nodes: outgoing[n] \subseteq Neighbors(n)
+    /\ mailbox \in [Nodes -> SUBSET Messages]
+    /\ \A n \in Nodes: \A msg \in mailbox[n]:
+        /\ msg.phase = "down" =>
+            /\ n \in outgoing[msg.sndr]
+            /\ \A mm \in mailbox[n]: \* at most one message per neighbor
+                mm.phase = "down" /\ mm.sndr = msg.sndr => mm = msg
+        /\ msg.phase = "up" =>
+                /\ msg.sndr \in outgoing[n]
+                /\ \A mm \in mailbox[n]: \* at most one message per neighbor
+                    mm.phase = "up" /\ mm.sndr = msg.sndr => mm = msg
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Yo-Yo algorithm as a state machine.                                      *)
+(****************************************************************************)
+Init ==
+    /\ active = [n \in Nodes |-> TRUE]
+    /\ phase = [n \in Nodes |-> "down"]
+    /\ incoming = [n \in Nodes |-> {m \in Neighbors(n): m < n}]
+    /\ outgoing = [n \in Nodes |-> {m \in Neighbors(n): m > n}]
+    /\ mailbox = [n \in Nodes |-> {}]
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Down phase: we distinguish sources and other nodes.                      *)
+(* Note that a node retains "down" messages after executing the phase       *)
+(* because they are used during the up phase.                               *)
+(****************************************************************************)
+DownSource(n) ==
+    /\ active[n]
+    /\ kind(n) = "source"
+    /\ phase[n] = "down"
+    /\ mailbox' = [m \in Nodes |->
+        IF m \in outgoing[n] THEN mailbox[m] \union {downMsg(n, n)}
+        ELSE mailbox[m]]
+    /\ phase' = [phase EXCEPT ![n] = "up"]
+    /\ UNCHANGED << active, incoming, outgoing >>
+
+DownOther(n) ==
+    /\ active[n]
+    /\ kind(n) \in {"internal", "sink"}
+    /\ phase[n] = "down"
+    /\ LET downMsgs == {msg \in mailbox[n]: msg.phase = "down"}
+        IN
+            /\ {msg.sndr: msg \in downMsgs} = incoming[n]
+            /\ LET min == Min({msg.val: msg \in downMsgs})
+                IN mailbox' = [m \in Nodes |->
+                    IF m \in outgoing[n]
+                    THEN mailbox[m] \union {downMsg(n, min)}
+                    ELSE mailbox[m]]
+    /\ phase' = [phase EXCEPT ![n] = "up"]
+    /\ UNCHANGED << active, incoming, outgoing >>
+
+Down(n) == DownSource(n) \/ DownOther(n)
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Up phase, again distinguishing sources and other nodes.                  *)
+(*                                                                          *)
+(* An internal or source node may already have received "down" messages     *)
+(* for the following round from neighbors that it still considers as        *)
+(* outgoing neighbors but for which the edge direction was reversed.        *)
+(* We therefore have to be careful to only consider "down" messages from    *)
+(* neighbors that the node considers as incoming, and also to preserve      *)
+(* "down" messages for the following round when cleaning the mailbox.       *)
+(****************************************************************************)
+UpSource(n) ==
+    /\ active[n]
+    /\ kind(n) = "source"
+    /\ phase[n] = "up"
+    /\ LET upMsgs == {msg \in mailbox[n]: msg.phase = "up"}
+            noSndrs == {msg.sndr: msg \in {mm \in upMsgs: mm.reply = "no"}}
+            pruned == {msg.sndr: msg \in {mm \in upMsgs: mm.prune}}
+        IN
+        /\ {msg.sndr: msg \in upMsgs} = outgoing[n]
+        /\ mailbox' = [mailbox EXCEPT ![n] = mailbox[n] \ upMsgs]
+        /\ incoming' = [incoming EXCEPT ![n] = noSndrs \ pruned]
+        /\ outgoing' = [outgoing EXCEPT ![n] = @ \ (noSndrs \union pruned)]
+    /\ phase' = [phase EXCEPT ![n] = "down"]
+    /\ active' = active
+
+UpOther(n) ==
+    /\ active[n]
+    /\ kind(n) \in {"internal", "sink"}
+    /\ phase[n] = "up"
+    /\ LET upMsgs == {msg \in mailbox[n]: msg.phase = "up"}
+            noSndrs == {msg.sndr: msg \in {mm \in upMsgs: mm.reply = "no"}}
+            pruned == {msg.sndr: msg \in {mm \in upMsgs: mm.prune}}
+            downMsgs == {msg \in mailbox[n]: msg.phase = "down" /\ msg.sndr \in incoming[n]}
+            valsRcvd == {msg.val: msg \in downMsgs}
+            senders(v) == {m \in incoming[n]: downMsg(m, v) \in downMsgs}
+            valSent(m) == (CHOOSE msg \in downMsgs: msg.sndr = m).val
+            isLoneSink == kind(n) = "sink" /\ Cardinality(incoming[n]) = 1
+        IN
+        /\ {msg.sndr: msg \in upMsgs} = outgoing[n] \* always true for sinks
+        /\    \* non-deterministically choose a sender for each value whose link
+              \* will not be pruned
+                \E keep \in {f \in [valsRcvd -> incoming[n]]:
+                        \A v \in valsRcvd: f[v] \in senders(v)}:
+                    /\ IF noSndrs = {} \* true in particular for sinks
+                        THEN LET min == Min({msg.val: msg \in downMsgs})
+                                minSndrs == {msg.sndr: msg \in {mm \in downMsgs: mm.val = min}}
+                            IN
+                            /\ mailbox' = [m \in Nodes |->
+                                IF m \in incoming[n]
+                                THEN mailbox[m] \union
+                                    {upMsg(n,
+                                        IF m \in minSndrs THEN "yes" ELSE "no",
+                                        (m /= keep[valSent(m)]) \/ isLoneSink)}
+                                ELSE IF m = n THEN mailbox[m] \ (upMsgs \union downMsgs)
+                                    ELSE mailbox[m]]
+                            /\ incoming' = [incoming EXCEPT ![n] =
+                                    IF isLoneSink THEN {} ELSE {keep[min]}]
+                            /\ outgoing' = [outgoing EXCEPT ![n] =
+                                    (@ \ pruned) \union
+                                        {keep[v]: v \in valsRcvd \ {min}}]
+                        ELSE
+                            /\ mailbox' = [m \in Nodes |->
+                                    IF m \in incoming[n]
+                                    THEN mailbox[m] \union {upMsg(n, "no", m /= keep[valSent(m)])}
+                                    ELSE IF m = n THEN mailbox[m] \ (upMsgs \union downMsgs)
+                                        ELSE mailbox[m]]
+                            /\ incoming' = [incoming EXCEPT ![n] = noSndrs \ pruned]
+                            /\ outgoing' = [outgoing EXCEPT ![n] =
+                                    (@ \ (noSndrs \union pruned)) \union
+                                        {keep[v]: v \in valsRcvd}]
+                    /\ active' = [active EXCEPT ![n] = ~isLoneSink]
+    /\ phase' = [phase EXCEPT ![n] = "down"]
+
+Up(n) == UpSource(n) \/ UpOther(n)
+
+--------------------------------------------------------------------------------
+
+Next == \E n \in Nodes: Down(n) \/ Up(n)
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+--------------------------------------------------------------------------------
+(****************************************************************************)
+(* Formulas used for verification.                                          *)
+(****************************************************************************)
+
+(****************************************************************************)
+(* Predicate asserting that there will always be at least two source nodes. *)
+(* Checking this as an invariant produces an execution that shows that all  *)
+(* sources except for the leader will be eliminated.                        *)
+(****************************************************************************)
+MoreThanOneSource == \E s1, s2 \in Nodes:
+    s1 /= s2 /\ kind(s1) = "source" /\ kind(s2) = "source"
+
+(****************************************************************************)
+(* Node m is an outgoing neighbor of node n iff n is an incoming neighbor   *)
+(* of m, except if the edge is being reversed, in which case there is a     *)
+(* "no" message in one of the mailboxes, or if the edge is being pruned,    *)
+(* in which case there is a corresponding message pending at node n.        *)
+(****************************************************************************)
+NeighborInv == \A m, n \in Nodes:
+    m \in outgoing[n] <=>
+        \/ n \in incoming[m]
+        \/
+            /\ n \in outgoing[m]
+            /\
+                \/ upMsg(n, "no", FALSE) \in mailbox[m]
+                \/ upMsg(m, "no", FALSE) \in mailbox[n]
+        \/
+                /\ n \notin (incoming[m] \union outgoing[m])
+                /\ \E r \in {"yes", "no"}: upMsg(m, r, TRUE) \in mailbox[n]
+                
+(****************************************************************************)
+(* The base algorithm without pruning ensures that no new sources are       *)
+(* generated during execution of the algorithm. Due to pruning, this        *)
+(* property may fail for the full algorithm, and TLC finds a counter-       *)
+(* example for the small example graph provided in the MC module (but the   *)
+(* property happens to be true for the larger graph).                       *)
+(****************************************************************************)
+NoNewSource ==
+[][\A n \in Nodes : kind(n)' = "source" => kind(n) = "source"]_vars
+
+(****************************************************************************)
+(* Termination condition: the node with smallest identity is the leader,    *)
+(* all other nodes are inactive, all mailboxes are empty.                   *)
+(* Check that the algorithm will reach such a state, and that this is the   *)
+(* only final (deadlock) state.                                             *)
+(****************************************************************************)
+Termination == \A n \in Nodes:
+    /\ IF n = Min(Nodes) THEN kind(n) = "leader" ELSE ~active[n]
+    /\ mailbox[n] = {}
+
+Liveness == <>Termination
+FinishIffTerminated == ~(ENABLED Next) <=> Termination
+================================================================================

--- a/libtlafmt/tests/snapshots/format__corpus@aba_asyn_byz.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@aba_asyn_byz.tla.snap
@@ -89,7 +89,7 @@ Receive(i, includeByz) ==
         /\ UNCHANGED << nSntE, nSntR, nRcvdE, nByz, pc >>
     \/
         /\ UNCHANGED vars
-    
+        
 (* Process i will send an ECHO message if it proposed 1 and did not send an ECHO message. 
    If process i proposed 0, did not send an ECHO message but has received greater than 
    (N + F) / 2 ECHO messages or (F + 1) READY messages, it will also send an ECHO messages. 
@@ -133,7 +133,7 @@ Next ==
         \/ SendReady(self)
         \/ Decide(self)
         \/ UNCHANGED vars
-        
+            
 (* Add weak fairness condition since we want to check liveness properties.  *)
 Spec == Init /\ [][Next]_vars
 /\ WF_vars(\E self \in Proc:

--- a/libtlafmt/tests/snapshots/format__corpus@bcastByz.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@bcastByz.tla.snap
@@ -158,7 +158,7 @@ Step(self) ==
         \/ UponNonFaulty(self)
         \/ UponAcceptNotSentBefore(self)
         \/ UponAcceptSentBefore(self)
-    
+        
 (* Some correct process does a transition step.*)
 Next ==
     \/ \E self \in Corr: Step(self)

--- a/libtlafmt/tests/snapshots/format__corpus@bcastFolklore.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@bcastFolklore.tla.snap
@@ -66,7 +66,7 @@ Receive(self) == (* a correct process self receives new messages *)
         /\ msgs \subseteq sent
         /\ rcvd[self] \subseteq msgs
         /\ rcvd' = [rcvd EXCEPT ![self] = msgs]
-        
+            
 (* If a correct process received an INIT message or was initialized with V1, 
    it accepts this message and then broadcasts ECHO to all.  
  *)
@@ -104,7 +104,7 @@ Step(self) ==
         \/ UponAccept(self)
         \/ UponCrash(self)
         \/ UNCHANGED << pc, sent, nCrashed, Corr >>
-    
+        
 (* the transition step *)
 Next == (\E self \in Corr: Step(self))
 

--- a/libtlafmt/tests/snapshots/format__corpus@bosco.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@bosco.tla.snap
@@ -184,7 +184,7 @@ Step(self) ==
         \/ UponUnderlying1(self)
         \/ UponUnderlyingUndecided(self)
         \/ pc' = pc /\ sent' = sent
-    
+        
 (* Initial step *)
 Init ==
     /\ pc \in [Corr -> {"V0", "V1"}]  (* Processes can propose V0 and V1. *)

--- a/libtlafmt/tests/snapshots/format__corpus@c1cs.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@c1cs.tla.snap
@@ -65,7 +65,7 @@ Receive(i) ==
         /\ msg \notin rcvdMsg[i]
         /\ rcvdMsg' = [rcvdMsg EXCEPT ![i] = rcvdMsg[i] \union {msg}]
         /\ UNCHANGED << pc, v, dValue, bcastMsg >>
-        
+            
 (* Broadcasts PROPOSED(v_i) *)
 Propose(i) ==
     /\ pc[i] = "PROPOSE"
@@ -80,18 +80,18 @@ Core_T1(i) ==
     /\ pc[i] = "DECIDE"
     /\ Cardinality({msg \in rcvdMsg[i]: msg.type = "Proposed"}) >= N - T
     /\ IF
-        /\ (\E tV \in Values: \A msg \in rcvdMsg[i]: msg.type = "Proposed" => msg.value = tV)
-    THEN
-        /\ dValue' = [dValue EXCEPT ![i] = CHOOSE tV \in Values: (Cardinality({msg \in rcvdMsg[i]: msg.type = "Proposed" /\ msg.value = tV}) >= N - T)]
-        /\ bcastMsg' = bcastMsg \union {makeDecisionMsg(dValue' [i], i)}
-        /\ pc' = [pc EXCEPT ![i] = "DONE"]
-        /\ UNCHANGED << v >>
-    ELSE
-        /\ IF \E tV \in Values: Cardinality({msg \in rcvdMsg[i]: msg.type = "Proposed" /\ msg.value = tV}) >= N - 2 * T
+            /\ (\E tV \in Values: \A msg \in rcvdMsg[i]: msg.type = "Proposed" => msg.value = tV)
         THEN
-            /\ v' = [v EXCEPT ![i] = CHOOSE tV \in Values: (Cardinality({msg \in rcvdMsg[i]: msg.type = "Proposed" /\ msg.value = tV}) >= N - 2 * T)]
-            /\ UNCHANGED << dValue, bcastMsg >>
-        ELSE UNCHANGED << dValue, v, bcastMsg >>
+            /\ dValue' = [dValue EXCEPT ![i] = CHOOSE tV \in Values: (Cardinality({msg \in rcvdMsg[i]: msg.type = "Proposed" /\ msg.value = tV}) >= N - T)]
+            /\ bcastMsg' = bcastMsg \union {makeDecisionMsg(dValue' [i], i)}
+            /\ pc' = [pc EXCEPT ![i] = "DONE"]
+            /\ UNCHANGED << v >>
+        ELSE
+        /\ IF \E tV \in Values: Cardinality({msg \in rcvdMsg[i]: msg.type = "Proposed" /\ msg.value = tV}) >= N - 2 * T
+            THEN
+                /\ v' = [v EXCEPT ![i] = CHOOSE tV \in Values: (Cardinality({msg \in rcvdMsg[i]: msg.type = "Proposed" /\ msg.value = tV}) >= N - 2 * T)]
+                /\ UNCHANGED << dValue, bcastMsg >>
+            ELSE UNCHANGED << dValue, v, bcastMsg >>
         /\ pc' = [pc EXCEPT ![i] = "CALL"]
     /\ UNCHANGED << rcvdMsg >>
 
@@ -105,7 +105,7 @@ T2(i) ==
         /\ bcastMsg' = bcastMsg \union {makeDecisionMsg(dValue' [i], i)}
         /\ pc' = [pc EXCEPT ![i] = "DONE"]
         /\ UNCHANGED << v, rcvdMsg >>
-        
+            
 (* Just to avoid deadlock checking. *)
 DoNothing(i) ==
     /\

--- a/libtlafmt/tests/snapshots/format__corpus@cbc_max.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@cbc_max.tla.snap
@@ -46,7 +46,7 @@ Msgs == Msg1s \union Msg2s
 (* Find the maximum value in arr *)
 MAX(arr) == CHOOSE maxVal \in Values:
     /\ (\E p \in Proc: arr[p] = maxVal)
-    /\ (\A p \in Proc: maxVal >= arr[p])
+        /\ (\A p \in Proc: maxVal >= arr[p])
 
 (* Line 1 *)
 Init ==
@@ -128,7 +128,7 @@ Phs2(i) ==
             /\ \A j \in Proc: \E m \in rcvdMsgs[i]: m.type = "Phs2" /\ m.sndr = j
             /\ pc' = [pc EXCEPT ![i] = "CHOOSE"]
             /\ UNCHANGED << v, w, nCrash, sntMsgs, dval, rcvdMsgs, V >>
-        
+                
 (* Process i has received all PHASE2 messages and therefore, it can deterministically
    choose a value appearing in V[i]. 
  *)

--- a/libtlafmt/tests/snapshots/format__corpus@cf1s_folklore.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@cf1s_folklore.tla.snap
@@ -114,7 +114,7 @@ Next ==
         \/ Decide(self)
         \/ Faulty(self)
         \/ UNCHANGED vars
-        
+            
 (* Add weak fairness condition since we want to check liveness properties.  *)
 (* We require that if UponV1 (UponNonFaulty, UponAcceptNotSent, UponAccept) *)
 (* ever becomes forever enabled, then this step must eventually occur.      *)

--- a/libtlafmt/tests/snapshots/format__corpus@clean.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@clean.tla.snap
@@ -68,10 +68,10 @@ anneal ==
 
 extend ==
     /\ tee = "Warm" \* too cool for extension
-    /\ tee' = "Hot" \* "Hot" is just right
-    /\ UNCHANGED << primer, template >>
-    /\ dna' = dna + hybrid \* assuming it just happens
-    /\ hybrid' = 0 \* all turned to dna
+        /\ tee' = "Hot" \* "Hot" is just right
+        /\ UNCHANGED << primer, template >>
+        /\ dna' = dna + hybrid \* assuming it just happens
+        /\ hybrid' = 0 \* all turned to dna
 
 (* initial state *)
 Init ==

--- a/libtlafmt/tests/snapshots/format__corpus@health_circuit.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@health_circuit.tla.snap
@@ -187,7 +187,7 @@ ThreadShouldProbe_probe(t) ==
         \/ ProbeStart(t) /\ UNCHANGED << counter_resets >>
         \/ ProbeContinue(t) /\ UNCHANGED << vars_counts, probe_windows >>
         \/ ProbeExhausted(t) /\ UNCHANGED << vars_counts, vars_probes >>
-    
+        
 \* The thread makes a request to the upstream and records the result.
 ThreadMakeRequest(t) ==
     /\ GetThread(t) = T_MakeRequest

--- a/libtlafmt/tests/snapshots/format__corpus@nbacc_ray97.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@nbacc_ray97.tla.snap
@@ -95,7 +95,7 @@ Step(self) ==
         \/ UponCrash(self)
         \/ UponSent(self)
         \/ pc' = pc /\ sent' = sent (* Do nothing but we need this to avoid deadlock *)
-    
+        
 (* Some processes vote YES. Others vote NO. *)
 Init ==
     /\ sent = {}

--- a/libtlafmt/tests/snapshots/format__corpus@nbacg_guer01.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@nbacg_guer01.tla.snap
@@ -73,11 +73,11 @@ Crash(i) ==
     /\ pc[i] /= "BYZ"
     /\ pc' = [pc EXCEPT ![i] = "BYZ"]
     /\ IF pc[i] = "YES"
-    THEN nSntYesF' = nSntYesF + 1
-    ELSE nSntYesF' = nSntYesF
+        THEN nSntYesF' = nSntYesF + 1
+        ELSE nSntYesF' = nSntYesF
     /\ IF pc[i] = "NO"
-    THEN nSntNoF' = nSntNoF + 1
-    ELSE nSntNoF' = nSntNoF
+        THEN nSntNoF' = nSntNoF + 1
+        ELSE nSntNoF' = nSntNoF
     /\ UNCHANGED << nSntNo, nSntYes, nRcvdNo, nRcvdYes, someFail >>
 
 (* A process starts receiving messages after sending its vote. If a process crashed or decides, 
@@ -99,7 +99,7 @@ Receive(i) ==
         /\ nRcvdYes[i] = nSntYes + nSntYesF (* all messages are received *)
         /\ nRcvdNo[i] = nSntNo + nSntNoF
         /\ UNCHANGED vars (* this conditions is added to avoid deadlocks *)
-    
+        
 (* A correct process sends YES messages to all processes. *)
 SendYes(i) ==
     /\ pc[i] = "YES"
@@ -151,7 +151,7 @@ Next ==
         \/ Commit(self)
         \/ UNCHANGED vars (* Avoid deadlocks. 
                                  After deciding, a correct process does nothing. *)
-        
+            
 (* 
   In this specification, a process can vote YES or NO. Weak fairness condition is added 
   since we want to check liveness properties.        

--- a/libtlafmt/tests/snapshots/format__corpus@raft.tla.snap
+++ b/libtlafmt/tests/snapshots/format__corpus@raft.tla.snap
@@ -336,8 +336,8 @@ HandleRequestVoteResponse(i, j, m) ==
             /\ voterLog' = [voterLog EXCEPT ![i] =
                 voterLog[i] @@ (j :> m.mlog)]
         \/
-            /\ ~m.mvoteGranted
-            /\ UNCHANGED << votesGranted, voterLog >>
+                /\ ~m.mvoteGranted
+                /\ UNCHANGED << votesGranted, voterLog >>
     /\ Discard(m)
     /\ UNCHANGED << serverVars, votedFor, leaderVars, logVars >>
 
@@ -363,12 +363,12 @@ HandleAppendEntriesRequest(i, j, m) ==
                         /\ state[i] = Follower
                         /\ ~logOk
                 /\ Reply([mtype |-> AppendEntriesResponse,
-                        mterm |-> currentTerm[i],
-                        msuccess |-> FALSE,
-                        mmatchIndex |-> 0,
-                        msource |-> i,
-                        mdest |-> j],
-                    m)
+                            mterm |-> currentTerm[i],
+                            msuccess |-> FALSE,
+                            mmatchIndex |-> 0,
+                            msource |-> i,
+                            mdest |-> j],
+                        m)
                 /\ UNCHANGED << serverVars, logVars >>
             \/ \* return to follower state
                 /\ m.mterm = currentTerm[i]
@@ -392,15 +392,15 @@ HandleAppendEntriesRequest(i, j, m) ==
                                     \* example if we process an old, duplicated request),
                                     \* but that doesn't really affect anything.
                             /\ commitIndex' = [commitIndex EXCEPT ![i] =
-                                m.mcommitIndex]
+                                    m.mcommitIndex]
                             /\ Reply([mtype |-> AppendEntriesResponse,
-                                    mterm |-> currentTerm[i],
-                                    msuccess |-> TRUE,
-                                    mmatchIndex |-> m.mprevLogIndex +
-                                        Len(m.mentries),
-                                    msource |-> i,
-                                    mdest |-> j],
-                                m)
+                                        mterm |-> currentTerm[i],
+                                        msuccess |-> TRUE,
+                                        mmatchIndex |-> m.mprevLogIndex +
+                                            Len(m.mentries),
+                                        msource |-> i,
+                                        mdest |-> j],
+                                    m)
                             /\ UNCHANGED << serverVars, log >>
                         \/ \* conflict: remove 1 entry
                             /\ m.mentries /= <<>>
@@ -466,14 +466,14 @@ Receive(m) ==
                 \/ DropStaleResponse(i, j, m)
                 \/ HandleRequestVoteResponse(i, j, m)
         \/
-            /\ m.mtype = AppendEntriesRequest
-            /\ HandleAppendEntriesRequest(i, j, m)
+                /\ m.mtype = AppendEntriesRequest
+                /\ HandleAppendEntriesRequest(i, j, m)
         \/
-            /\ m.mtype = AppendEntriesResponse
-            /\
-                \/ DropStaleResponse(i, j, m)
-                \/ HandleAppendEntriesResponse(i, j, m)
-            
+                /\ m.mtype = AppendEntriesResponse
+                /\
+                    \/ DropStaleResponse(i, j, m)
+                    \/ HandleAppendEntriesResponse(i, j, m)
+                    
 \* End of message handlers.
 --------------------------------------------------------------------------------
 \* Network state transitions


### PR DESCRIPTION
This fixes the last remaining major cause of spec breakage.

Fixes https://github.com/domodwyer/tlafmt/issues/57

---

* fix: connective item body indentation (f615989)
      
      Indent the body of a conjunction / disjunction list item.
      
      This fixes spec breakage caused by characters appearing in the list
      column due to lack of indentation.