### PR TITLE
refactor: simplify newline token delimiters

### DIFF
--- a/libtlafmt/src/ast_format/node.rs
+++ b/libtlafmt/src/ast_format/node.rs
@@ -781,7 +781,7 @@ X == [version: Nat]
     }
 
     #[test]
-    fn test_inline_comment_col_0() {
+    fn test_inline_comment_empty_ident() {
         assert_rewrite!(
             r#"
 ---- MODULE B ----

--- a/libtlafmt/src/token.rs
+++ b/libtlafmt/src/token.rs
@@ -321,8 +321,8 @@ impl Token<'_> {
 
             // Newlines are never automatically followed by whitespace.
             (Token::Newline | Token::SourceNewline, _) => 0,
+            (_, Token::Newline | Token::SourceNewline) => 0,
 
-            (Token::Raw(_), Token::Newline | Token::SourceNewline) => 0,
             (Token::Raw(s), _) if s.ends_with("\n") => 0,
             (Token::Raw(_), _) => 1,
             (_, Token::Raw(_)) => 1,
@@ -384,9 +384,7 @@ impl Token<'_> {
             // No space between any token and the listed tokens.
             (
                 _,
-                Token::SourceNewline
-                | Token::Newline
-                | Token::ParenClose
+                Token::ParenClose
                 | Token::SquareClose
                 | Token::CurlyClose
                 | Token::Comma


### PR DESCRIPTION
Less is more.

---

* refactor: simplify newline token delimiters (c501a0f)
      
      Simplify the newline whitespace logic.