### PR TITLE
ci: separate caches for fuzz targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -59,8 +59,8 @@ jobs:
         id: target-dir
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-fuzz-target-dir-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-fuzz-target-dir
+          key: ${{ runner.os }}-fuzz-target-dir-${{ matrix.fuzz_target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-fuzz-target-dir-${{ matrix.fuzz_target }}
           path: libtlafmt/fuzz/target
 
       - name: Run fuzzer


### PR DESCRIPTION
This should speed up CI.

---

* ci: separate caches for fuzz targets (a3546f3)
      
      This should increase cache hits for each fuzzer.