### PR TITLE
ci: restore any fuzz target if not cache hit

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -60,7 +60,9 @@ jobs:
         uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-fuzz-target-dir-${{ matrix.fuzz_target }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-fuzz-target-dir-${{ matrix.fuzz_target }}
+          restore-keys: |
+            ${{ runner.os }}-fuzz-target-dir-${{ matrix.fuzz_target }}
+            ${{ runner.os }}-fuzz-target-dir
           path: libtlafmt/fuzz/target
 
       - name: Run fuzzer


### PR DESCRIPTION
More cache.

---

* ci: restore any fuzz target if not cache hit (9075658)
      
      If a cache entry does not exist for the fuzz target, restore any target.